### PR TITLE
Add payment table and management methods

### DIFF
--- a/core/DatabaseManager.php
+++ b/core/DatabaseManager.php
@@ -162,8 +162,13 @@ interface DatabaseManager
     public function unenrollCatechumenFromGroup(int $cid, int $catecheticalYear, int $catechism, string $group);        // Unenrolls a catechumen from a catechesis group
     public function unenrollCatechumenFromAllGroups(int $cid, bool $useTransaction=true);                               // Unenrolls a catechumen from all the groups where he/she is enrolled
     public function updateCatechumenEnrollmentPayment(int $cid, int $catecheticalYear, int $catechism, string $group,   // Updates the payment status of a catechumen enrollment
-                                                       bool $paid);
+                                                        bool $paid);
     public function getCatecheticalYearsWhereCatechumenIsNotEnrolled(int $cid);                                         // Returns all the catechetical years where the catechumen is NOT enrolled
+
+    // Payments
+    public function insertPayment(int $cid, float $valor, string $username, string $status);                           // Registers a new payment for a catechumen
+    public function getPaymentsByUser(string $username);                                                                // Returns all payments made by a given user
+    public function getPaymentsByCatechumen(int $cid);                                                                  // Returns all payments associated with a catechumen
 
 
     // Sacraments

--- a/updater/sql_scripts/002_create_pagamento.sql
+++ b/updater/sql_scripts/002_create_pagamento.sql
@@ -1,0 +1,10 @@
+CREATE TABLE pagamento (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    cid INT NOT NULL,
+    username VARCHAR(50) NOT NULL,
+    valor DECIMAL(10,2) NOT NULL,
+    data_hora DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    status VARCHAR(20) NOT NULL,
+    FOREIGN KEY (cid) REFERENCES catequizando(cid),
+    FOREIGN KEY (username) REFERENCES utilizador(username)
+);


### PR DESCRIPTION
## Summary
- create SQL migration for new `pagamento` table
- expose payment methods in `DatabaseManager` interface
- implement payment methods in `PdoDatabaseManager`

## Testing
- `php -l core/DatabaseManager.php`
- `php -l core/PdoDatabaseManager.php`


------
https://chatgpt.com/codex/tasks/task_e_687f989c18348328ac30f0eca5a3196f