### PR TITLE
Fix duplicate payment declarations

### DIFF
--- a/core/DatabaseManager.php
+++ b/core/DatabaseManager.php
@@ -166,8 +166,6 @@ interface DatabaseManager
     public function getCatecheticalYearsWhereCatechumenIsNotEnrolled(int $cid);                                         // Returns all the catechetical years where the catechumen is NOT enrolled
 
     // Payments
-    public function insertPayment(int $cid, float $valor, string $username, string $status);                           // Registers a new payment for a catechumen
-    public function getPaymentsByUser(string $username);                                                                // Returns all payments made by a given user
     public function getPaymentsByCatechumen(int $cid);                                                                  // Returns all payments associated with a catechumen
 
 


### PR DESCRIPTION
## Summary
- clean up interface definitions in `PdoDatabaseManager.php`
- remove redundant declarations in `DatabaseManager.php`
- keep single implementations for payment functions

## Testing
- `php -l core/PdoDatabaseManager.php`
- `php -l core/DatabaseManager.php`

------
https://chatgpt.com/codex/tasks/task_e_687f95ae8f74832897cccfe7133d7132