### PR TITLE
Add payment verification service

### DIFF
--- a/core/Configurator.php
+++ b/core/Configurator.php
@@ -123,6 +123,9 @@ class Configurator
     const KEY_ENROLLMENT_PAYMENT_AMOUNT = "ENROLLMENT_PAYMENT_AMOUNT";                                                  //Enrollment price tag (euro)
     const KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS = "ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS";                //Whether the payer is suggested to donate more than the required amount
     const KEY_ENROLLMENT_PAYMENT_PROOF = "ENROLLMENT_PAYMENT_PROOF";                                                    //E-mail address or URL (ex: a cloud folder) to which payers should send the proof of payment
+    const KEY_PAYMENT_PROVIDER_URL = "PAYMENT_PROVIDER_URL";            //Endpoint used to verify enrollment payments
+    const KEY_PAYMENT_PROVIDER_TOKEN = "PAYMENT_PROVIDER_TOKEN";        //Authentication token for the payment provider API
+
 
     const KEY_CATECHESIS_NEXTCLOUD_BASE_URL = "CATECHESIS_NEXTCLOUD_BASE_URL";                                          //Path to Nextcloud front page
     const KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL = "CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL";                //Path to public shared folder in Nextcloud to store virtual catechesis resources
@@ -172,7 +175,8 @@ class Configurator
                 self::KEY_ENROLLMENT_PAYMENT_AMOUNT => new ConfigurationObject(self::KEY_ENROLLMENT_PAYMENT_AMOUNT, ConfigurationObject::TYPE_FLOAT, 100.0),
                 self::KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS => new ConfigurationObject(self::KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS, ConfigurationObject::TYPE_BOOL, true),
                 self::KEY_ENROLLMENT_PAYMENT_PROOF => new ConfigurationObject(self::KEY_ENROLLMENT_PAYMENT_PROOF, ConfigurationObject::TYPE_STRING, null),
-
+                self::KEY_PAYMENT_PROVIDER_URL => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_URL, ConfigurationObject::TYPE_STRING, null),
+                self::KEY_PAYMENT_PROVIDER_TOKEN => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_TOKEN, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_CATECHESIS_NEXTCLOUD_BASE_URL => new ConfigurationObject(self::KEY_CATECHESIS_NEXTCLOUD_BASE_URL, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL => new ConfigurationObject(self::KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL, ConfigurationObject::TYPE_STRING, null),
 

--- a/core/PaymentVerificationService.php
+++ b/core/PaymentVerificationService.php
@@ -1,0 +1,66 @@
+<?php
+namespace catechesis;
+
+use Exception;
+use catechesis\Configurator;
+
+/**
+ * Service to check whether a multibanco reference was paid using an external
+ * payment provider API. This implementation expects the API to return a JSON
+ * payload with fields 'paid' and 'amount'.
+ */
+class PaymentVerificationService
+{
+    private string $endpoint;
+    private string $token;
+    private int $timeout;
+
+    public function __construct(string $endpoint = null, string $token = null, int $timeout = 10)
+    {
+        $this->endpoint = $endpoint ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PAYMENT_PROVIDER_URL);
+        $this->token     = $token ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PAYMENT_PROVIDER_TOKEN);
+        $this->timeout   = $timeout;
+    }
+
+    /**
+     * Queries the provider and checks if the reference has been paid.
+     *
+     * @param int    $entity   Payment entity number
+     * @param string $reference Payment reference number
+     * @param float  $amount    Expected amount
+     *
+     * @return bool True if the provider reports the reference was paid with at least the given amount.
+     * @throws Exception When the provider is unreachable or returns an invalid response.
+     */
+    public function verifyPayment(int $entity, string $reference, float $amount): bool
+    {
+        if (!$this->endpoint || !$this->token) {
+            throw new Exception('Payment provider not configured.');
+        }
+
+        $query = http_build_query(['entity' => $entity, 'reference' => $reference]);
+        $url   = rtrim($this->endpoint, '/') . '/?' . $query;
+
+        $options = [
+            'http' => [
+                'header' => "Authorization: Bearer {$this->token}\r\n",
+                'method' => 'GET',
+                'timeout' => $this->timeout,
+            ],
+        ];
+
+        $context  = stream_context_create($options);
+        $response = @file_get_contents($url, false, $context);
+        if ($response === false) {
+            throw new Exception('Failed to connect to payment provider.');
+        }
+
+        $data = json_decode($response, true);
+        if (!is_array($data) || !isset($data['paid']) || !isset($data['amount'])) {
+            throw new Exception('Invalid response from payment provider.');
+        }
+
+        return ($data['paid'] === true || $data['paid'] === 1 || $data['paid'] === '1')
+            && floatval($data['amount']) >= $amount;
+    }
+}

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -11,6 +11,7 @@ require_once(__DIR__ . '/core/UserData.php');
 require_once(__DIR__ . "/core/DataValidationUtils.php");
 require_once(__DIR__ . '/core/catechist_belongings.php');
 require_once(__DIR__ . "/core/PdoDatabaseManager.php");
+require_once(__DIR__ . '/core/PaymentVerificationService.php');
 require_once(__DIR__ . "/core/domain/Sacraments.php");
 require_once(__DIR__ . "/core/domain/Marriage.php");
 require_once(__DIR__ . "/gui/widgets/WidgetManager.php");
@@ -22,6 +23,7 @@ use catechesis\Authenticator;
 use catechesis\Configurator;
 use catechesis\UserData;
 use catechesis\utils;
+use catechesis\PaymentVerificationService;
 use core\domain\Marriage;
 use core\domain\Sacraments;
 use catechesis\gui\WidgetManager;
@@ -228,8 +230,23 @@ $menu->renderHTML();
 
 		$_SESSION['quer_inscrever'] = $quer_inscrever;
 		$_SESSION['catecismo'] = $catecismo;
-		$_SESSION['turma'] = $turma;
-		$_SESSION['pago'] = $pago;
+                $_SESSION['turma'] = $turma;
+                $_SESSION['pago'] = $pago;
+
+                // Try to automatically confirm payment using configured provider
+                try
+                {
+                    $entity = Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_ENTITY);
+                    $reference = Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_REFERENCE);
+                    $amount = floatval(Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT));
+                    $verifier = new PaymentVerificationService();
+                    if ($verifier->verifyPayment(intval($entity), strval($reference), $amount))
+                        $pago = 'on';
+                }
+                catch (Exception $e)
+                {
+                    // Ignore verification errors and proceed with submitted value
+                }
  		
 		
 	  	


### PR DESCRIPTION
## Summary
- research IfthenPay reference verification capability (Portuguese MB payment)
- support configuration of provider endpoint and token
- add `PaymentVerificationService` to check if a Multibanco reference was paid
- automatically verify payment during enrollment approval

## Testing
- `php -l core/PaymentVerificationService.php`
- `php -l processarInscricao.php`


------
https://chatgpt.com/codex/tasks/task_e_687fdca0193c83289d4b2c0cc559cc32