### PR TITLE
Validate multibanco info

### DIFF
--- a/core/DataValidationUtils.php
+++ b/core/DataValidationUtils.php
@@ -139,4 +139,34 @@ class DataValidationUtils
         $letterNumber = '/^(?=.*[a-zA-Z])(?=.*[0-9])/';
         return (strlen($password)>=$MIN_LENGHT && preg_match($letterNumber, $password));
     }
+
+    /**
+     * Validates a Multibanco entity number. It should contain exactly five digits.
+     * @param string $value
+     * @return bool
+     */
+    public static function validateMbEntity(string $value)
+    {
+        return preg_match('/^[0-9]{5}$/', $value);
+    }
+
+    /**
+     * Validates a Multibanco reference number. It should contain exactly nine digits.
+     * @param string $value
+     * @return bool
+     */
+    public static function validateMbReference(string $value)
+    {
+        return preg_match('/^[0-9]{9}$/', $value);
+    }
+
+    /**
+     * Checks whether a numeric string represents a positive float value.
+     * @param string $value
+     * @return bool
+     */
+    public static function validatePositiveFloat(string $value)
+    {
+        return is_numeric($value) && floatval($value) > 0;
+    }
 }

--- a/gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php
+++ b/gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php
@@ -359,28 +359,57 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
 
             $enrollmentCustomText =  Utils::sanitizeKeepFormattingTags($_POST['info_text']);
             $showPaymentData =  Utils::sanitizeInput($_POST['enable_payment']); $showPaymentData = ($showPaymentData=="on");
-            $paymentEntity =  intval(Utils::removeWhiteSpaces(Utils::sanitizeInput($_POST['entity'])));
-            $paymentReference = intval(Utils::removeWhiteSpaces(Utils::sanitizeInput($_POST['reference'])));
-            $paymentAmount =  floatval(Utils::sanitizeInput($_POST['amount']));
+            $paymentEntity =  Utils::removeWhiteSpaces(Utils::sanitizeInput($_POST['entity']));
+            $paymentReference = Utils::removeWhiteSpaces(Utils::sanitizeInput($_POST['reference']));
+            $paymentAmount =  Utils::sanitizeInput($_POST['amount']);
             $acceptDonations = Utils::sanitizeInput($_POST['allow_donations']); $acceptDonations = ($acceptDonations=="on");
             $paymentProof = Utils::sanitizeInput($_POST['proof']);
 
-            try
+            $inputs_valid = true;
+            if($showPaymentData)
             {
-                Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_CUSTOM_TEXT, $enrollmentCustomText);
-                Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_SHOW_PAYMENT_DATA, $showPaymentData);
-                Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_ENTITY, $paymentEntity);
-                Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_REFERENCE, $paymentReference);
-                Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT, $paymentAmount);
-                Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS, $acceptDonations);
-                Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_PROOF, $paymentProof);
+                if(!DataValidationUtils::validateMbEntity($paymentEntity))
+                {
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> A entidade indicada é inválida.</div>");
+                    $inputs_valid = false;
+                }
 
-                writeLogEntry("Modificou configurações das inscrições/renovações de matrícula online.");
-                echo("<div class=\"alert alert-success\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Sucesso!</strong> Modificou as configurações das inscrições/renovações de matrícula online.</div>");
+                if(!DataValidationUtils::validateMbReference($paymentReference))
+                {
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> A referência indicada é inválida.</div>");
+                    $inputs_valid = false;
+                }
+
+                if(!DataValidationUtils::validatePositiveFloat($paymentAmount))
+                {
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O montante indicado é inválido.</div>");
+                    $inputs_valid = false;
+                }
             }
-            catch (\Exception $e)
+
+            $paymentEntity = intval($paymentEntity);
+            $paymentReference = intval($paymentReference);
+            $paymentAmount = floatval($paymentAmount);
+
+            if($inputs_valid)
             {
-                echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . $e->getMessage() . "</div>");
+                try
+                {
+                    Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_CUSTOM_TEXT, $enrollmentCustomText);
+                    Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_SHOW_PAYMENT_DATA, $showPaymentData);
+                    Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_ENTITY, $paymentEntity);
+                    Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_REFERENCE, $paymentReference);
+                    Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT, $paymentAmount);
+                    Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS, $acceptDonations);
+                    Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_PROOF, $paymentProof);
+
+                    writeLogEntry("Modificou configurações das inscrições/renovações de matrícula online.");
+                    echo("<div class=\"alert alert-success\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Sucesso!</strong> Modificou as configurações das inscrições/renovações de matrícula online.</div>");
+                }
+                catch (\Exception $e)
+                {
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . $e->getMessage() . "</div>");
+                }
             }
         }
     }

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -498,13 +498,17 @@ $navbar->renderHTML();
                 $acceptDonations =  Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS);
                 $paymentProof =  Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_PROOF);
 
+                $validPaymentData = DataValidationUtils::validateMbEntity(strval($paymentEntity)) &&
+                                   DataValidationUtils::validateMbReference(strval($paymentReference)) &&
+                                   DataValidationUtils::validatePositiveFloat(strval($paymentAmount));
+
                 $proofType = 'text';
                 if(DataValidationUtils::validateEmail($paymentProof))
                     $proofType = "email";
                 else if(DataValidationUtils::validateURL($paymentProof))
                     $proofType = "url";
 
-                if($showPaymentData)
+                if($showPaymentData && $validPaymentData)
                 {
                     ?>
                     <!-- Referencia multibanco -->

--- a/publico/doRenovarMatricula.php
+++ b/publico/doRenovarMatricula.php
@@ -193,13 +193,17 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
             $acceptDonations =  Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS);
             $paymentProof =  Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_PROOF);
 
+            $validPaymentData = DataValidationUtils::validateMbEntity(strval($paymentEntity)) &&
+                               DataValidationUtils::validateMbReference(strval($paymentReference)) &&
+                               DataValidationUtils::validatePositiveFloat(strval($paymentAmount));
+
             $proofType = 'text';
             if(DataValidationUtils::validateEmail($paymentProof))
                 $proofType = "email";
             else if(DataValidationUtils::validateURL($paymentProof))
                 $proofType = "url";
 
-            if($showPaymentData)
+            if($showPaymentData && $validPaymentData)
             {
             ?>
             <!-- Referencia multibanco -->


### PR DESCRIPTION
## Summary
- add Multibanco validators and positive float check
- validate payment details before storing settings
- check Multibanco data when showing payment information

## Testing
- `php -l core/DataValidationUtils.php`
- `php -l gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php`
- `php -l publico/doInscrever.php`
- `php -l publico/doRenovarMatricula.php`

------
https://chatgpt.com/codex/tasks/task_e_687fdc9ef7dc8328b1a7f05da4ea2869