### PR TITLE
Implement CSRF protection

### DIFF
--- a/core/Utils.php
+++ b/core/Utils.php
@@ -474,6 +474,36 @@ class Utils
         return $token;
     }
 
+    /**
+     * Generates (or retrieves) the CSRF token stored in the current session.
+     * @param int $length
+     * @return string
+     * @throws Exception
+     */
+    public static function getCSRFToken(int $length = 32)
+    {
+        if(session_status() === PHP_SESSION_NONE)
+            session_start();
+
+        if(!isset($_SESSION['csrf_token']))
+            $_SESSION['csrf_token'] = self::secureRandomString($length);
+
+        return $_SESSION['csrf_token'];
+    }
+
+    /**
+     * Verifies that the CSRF token provided matches the one stored in the session.
+     * @param string|null $token
+     * @return bool
+     */
+    public static function verifyCSRFToken(?string $token)
+    {
+        if(session_status() === PHP_SESSION_NONE)
+            session_start();
+
+        return (isset($_SESSION['csrf_token']) && isset($token) && hash_equals($_SESSION['csrf_token'], $token));
+    }
+
 
     /**
      * Interrupts a script and returns an error message in the form of an HTML paragraph.

--- a/gui/widgets/configuration_panels/AbstractSettingsPanel/AbstractSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/AbstractSettingsPanel/AbstractSettingsPanelWidget.php
@@ -157,6 +157,7 @@ abstract class AbstractSettingsPanelWidget extends Widget
         ?>
         <div id="<?=$this->getID()?>" class="settings_panel_widget<?= $this->getCustomClassesString()?>" style="<?=$this->getCustomInlineStyle()?>">
             <form role="form" id="form_settings_<?= $this->getID() ?>" name="form_admin" onsubmit="return on_submit_<?= $this->getID() ?>()" action="<?= $this->post_URL ?>" method="post">
+                <input type="hidden" name="csrf_token" value="<?= \catechesis\Utils::getCSRFToken() ?>">
                 <div class="panel <?= $this->panel_style ?>" id="<?=$this->getID()?>_panel">
                     <div class="panel-heading" id="<?=$this->getID()?>_panel_heading"><?= $this->panel_title ?>
                         <?php

--- a/gui/widgets/configuration_panels/CatechesisSettingsPanel/CatechesisSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/CatechesisSettingsPanel/CatechesisSettingsPanelWidget.php
@@ -125,6 +125,12 @@ class CatechesisSettingsPanelWidget extends AbstractSettingsPanelWidget
         if($this->requires_admin_privileges && !Authenticator::isAdmin())
             return; //Do not render this widget if the user is not admin and it requires admin priviledges
 
+        if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+        {
+            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+            return;
+        }
+
         if($_POST['action'] == self::$ACTION_PARAMETER && Authenticator::isAdmin())
         {
             $numCatechisms = intval($_POST['num_catechisms']);

--- a/gui/widgets/configuration_panels/CatechumensEvaluationActivationPanel/CatechumensEvaluationActivationPanelWidget.php
+++ b/gui/widgets/configuration_panels/CatechumensEvaluationActivationPanel/CatechumensEvaluationActivationPanelWidget.php
@@ -92,6 +92,12 @@ class CatechumensEvaluationActivationPanelWidget extends AbstractSettingsPanelWi
         if($this->requires_admin_privileges && !Authenticator::isAdmin())
             return; //Do not render this widget if the user is not admin and it requires admin priviledges
 
+        if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+        {
+            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+            return;
+        }
+
         //Activar/desactivar
         if($_POST['action'] == self::$ACTION_PARAMETER && Authenticator::isAdmin())
         {

--- a/gui/widgets/configuration_panels/FrontPageCustomizationPanel/FrontPageCustomizationPanelWidget.php
+++ b/gui/widgets/configuration_panels/FrontPageCustomizationPanel/FrontPageCustomizationPanelWidget.php
@@ -215,6 +215,11 @@ class FrontPageCustomizationPanelWidget extends AbstractSettingsPanelWidget
      */
     public function handlePost()
     {
+        if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+        {
+            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+            return;
+        }
         $action = Utils::sanitizeInput($_POST['action']);
 
         //Edit public front page data

--- a/gui/widgets/configuration_panels/GDPRParishSettingsPanel/GDPRParishSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/GDPRParishSettingsPanel/GDPRParishSettingsPanelWidget.php
@@ -178,6 +178,12 @@ class GDPRParishSettingsPanelWidget extends AbstractSettingsPanelWidget
         if($this->requires_admin_privileges && !Authenticator::isAdmin())
             return; //Do not render this widget if the user is not admin and it requires admin priviledges
 
+        if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+        {
+            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+            return;
+        }
+
         $action = Utils::sanitizeInput($_POST['action']);
 
         //Edit parish data

--- a/gui/widgets/configuration_panels/NextcloudIntegrationConfigurationPanel/NextcloudIntegrationConfigurationPanelWidget.php
+++ b/gui/widgets/configuration_panels/NextcloudIntegrationConfigurationPanel/NextcloudIntegrationConfigurationPanelWidget.php
@@ -112,6 +112,12 @@ class NextcloudIntegrationConfigurationPanelWidget extends AbstractSettingsPanel
         if($this->requires_admin_privileges && !Authenticator::isAdmin())
             return; //Do not render this widget if the user is not admin and it requires admin priviledges
 
+        if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+        {
+            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+            return;
+        }
+
         //Activar/desactivar
         if($_POST['action'] == self::$ACTION_PARAMETER && Authenticator::isAdmin())
         {

--- a/gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php
+++ b/gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php
@@ -318,6 +318,12 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
         if($this->requires_admin_privileges && !Authenticator::isAdmin())
             return; //Do not render this widget if the user is not admin and it requires admin priviledges
 
+        if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+        {
+            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+            return;
+        }
+
         if($_POST['action'] == self::$ACTION_CHANGE_STATUS && Authenticator::isAdmin())
         {
             // Enable/disable online enrollments

--- a/gui/widgets/configuration_panels/ParishSettingsPanel/ParishSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/ParishSettingsPanel/ParishSettingsPanelWidget.php
@@ -309,6 +309,12 @@ class ParishSettingsPanelWidget extends AbstractSettingsPanelWidget
         if($this->requires_admin_privileges && !Authenticator::isAdmin())
             return; //Do not render this widget if the user is not admin and it requires admin priviledges
 
+        if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+        {
+            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+            return;
+        }
+
         $action = Utils::sanitizeInput($_POST['action']);
 
         //Edit parish data

--- a/gui/widgets/configuration_panels/UserAccountConfigurationPanel/UserAccountConfigurationPanelWidget.php
+++ b/gui/widgets/configuration_panels/UserAccountConfigurationPanel/UserAccountConfigurationPanelWidget.php
@@ -296,6 +296,11 @@ class UserAccountConfigurationPanelWidget extends AbstractSettingsPanelWidget
 
         $ulogin = new uLogin('catechesis\Authenticator::appLogin', 'catechesis\Authenticator::appLoginFail');
 
+        if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+        {
+            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+            return;
+        }
         $action = Utils::sanitizeInput($_POST['action']);
 
         //Editar dados da conta

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(__DIR__ . '/../core/config/catechesis_config.inc.php');
+require_once(__DIR__ . '/../core/session_init.php');
 require_once(__DIR__ . '/../core/DataValidationUtils.php');
 require_once(__DIR__ . '/../core/Utils.php');
 require_once(__DIR__ . '/../core/UserData.php');
@@ -128,8 +129,13 @@ $navbar->renderHTML();
 
 
 	// Carregamento das variáveis através do metodo POST
-	if ($_SERVER["REQUEST_METHOD"] == "POST")
-	{
+        if ($_SERVER["REQUEST_METHOD"] == "POST")
+        {
+            if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+            {
+                echo("<div class=\"alert alert-danger\"><strong>ERRO!</strong> Pedido inválido.</div>");
+                die();
+            }
         //Dados biograficos do catequizando
         $foto_data = Utils::sanitizeInput($_POST['foto_data']);		// Foto codificada em base64
 	  	$nome = Utils::sanitizeInput($_POST['nome']);

--- a/publico/doRenovarMatricula.php
+++ b/publico/doRenovarMatricula.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(__DIR__ . '/../core/Utils.php');
+require_once(__DIR__ . '/../core/session_init.php');
 require_once(__DIR__ . '/../core/DataValidationUtils.php');
 require_once(__DIR__ . '/../core/enrollment_functions.php');
 require_once(__DIR__ . '/../authentication/securimage/securimage.php'); //Captcha
@@ -93,6 +94,11 @@ $navbar->renderHTML();
 
 if ($_SERVER["REQUEST_METHOD"] == "POST")
 {
+    if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+    {
+        echo("<div class=\"alert alert-danger\"><strong>ERRO!</strong> Pedido inválido.</div>");
+        die();
+    }
     $enc_edu_nome = Utils::sanitizeInput($_POST['enc_edu_nome']);
     $enc_edu_email = Utils::sanitizeInput($_POST['enc_edu_email']);
     $enc_edu_tel = Utils::sanitizeInput($_POST['enc_edu_tel']);

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(__DIR__ . '/../core/config/catechesis_config.inc.php');
+require_once(__DIR__ . '/../core/session_init.php');
 require_once(__DIR__ . '/../core/Utils.php');
 require_once(__DIR__ . '/../core/Configurator.php');
 require_once(__DIR__ . '/../core/domain/Locale.php');
@@ -101,6 +102,7 @@ $pageUI->addWidget($footer);
     <div class="container">
 
         <form role="form" onsubmit="return validar();" action="doInscrever.php<?php if($_REQUEST['modo']=='editar'){ echo('?modo=editar');}?>" method="post">
+            <input type="hidden" name="csrf_token" value="<?= \catechesis\Utils::getCSRFToken() ?>">
 
           <div class="panel panel-default" id="painel_ficha">
            <div class="panel-body">

--- a/publico/renovarMatricula.php
+++ b/publico/renovarMatricula.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(__DIR__ . '/../core/Configurator.php');
+require_once(__DIR__ . '/../core/session_init.php');
 require_once(__DIR__ . '/../authentication/securimage/securimage.php');
 require_once(__DIR__ . '/../core/Utils.php');
 require_once(__DIR__ . '/../gui/widgets/WidgetManager.php');
@@ -86,6 +87,7 @@ $navbar->renderHTML();
 
 
     <form role="form" action="doRenovarMatricula.php" method="post" id="form_renovar_matricula" onsubmit="return validar();">
+        <input type="hidden" name="csrf_token" value="<?= \catechesis\Utils::getCSRFToken() ?>">
         <div class="panel panel-default collapse in" id="painel_renovacao">
             <div class="panel-heading">Preencher todos os campos</div>
             <div class="panel-body">


### PR DESCRIPTION
## Summary
- add CSRF token utilities
- include hidden CSRF tokens in public forms and config panels
- verify tokens in enrollment handlers and admin configuration panels
- start a session in public pages that require the CSRF token

## Testing
- `php -l core/Utils.php`
- `php -l gui/widgets/configuration_panels/AbstractSettingsPanel/AbstractSettingsPanelWidget.php`
- `php -l gui/widgets/configuration_panels/CatechesisSettingsPanel/CatechesisSettingsPanelWidget.php`
- `php -l gui/widgets/configuration_panels/CatechumensEvaluationActivationPanel/CatechumensEvaluationActivationPanelWidget.php`
- `php -l gui/widgets/configuration_panels/FrontPageCustomizationPanel/FrontPageCustomizationPanelWidget.php`
- `php -l gui/widgets/configuration_panels/GDPRParishSettingsPanel/GDPRParishSettingsPanelWidget.php`
- `php -l gui/widgets/configuration_panels/NextcloudIntegrationConfigurationPanel/NextcloudIntegrationConfigurationPanelWidget.php`
- `php -l gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php`
- `php -l gui/widgets/configuration_panels/ParishSettingsPanel/ParishSettingsPanelWidget.php`
- `php -l gui/widgets/configuration_panels/UserAccountConfigurationPanel/UserAccountConfigurationPanelWidget.php`
- `php -l publico/inscrever.php`
- `php -l publico/renovarMatricula.php`
- `php -l publico/doInscrever.php`
- `php -l publico/doRenovarMatricula.php`


------
https://chatgpt.com/codex/tasks/task_e_687fdc9d658c83288ea5df11b47e11cc