### PR TITLE
Fix warnings in catechist search filters

### DIFF
--- a/pesquisarCatequista.php
+++ b/pesquisarCatequista.php
@@ -144,7 +144,7 @@ $menu->renderHTML();
     <div class="col-xs-6">
  	 <label for="ano_catequetico">Ano catequético: </label> 
  	 <select name="ano_catequetico" >
-    		<option value="" <?php if (!$_POST['ano_catequetico'] || $_POST['ano_catequetico']=="") echo("selected"); ?>>Todos</option>
+                <option value="" <?php if (!isset($_POST['ano_catequetico']) || $_POST['ano_catequetico']=="") echo("selected"); ?>>Todos</option>
 	<?php
 
         $db = new PdoDatabaseManager();
@@ -164,7 +164,7 @@ $menu->renderHTML();
         foreach($result as $row)
         {
             echo("<option value='" . $row['ano_lectivo'] . "'");
-            if ($_SERVER["REQUEST_METHOD"] == "POST" && $_POST['ano_catequetico']==$row['ano_lectivo'])
+            if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['ano_catequetico']) && $_POST['ano_catequetico']==$row['ano_lectivo'])
                 echo(" selected");
             echo(">");
             echo("" . Utils::formatCatecheticalYear($row['ano_lectivo']) . "</option>\n");
@@ -180,7 +180,7 @@ $menu->renderHTML();
    	<div class="col-xs-6">
    		<label for="catequista">Catequista:</label>
 		<select name="catequista">
-			<option value="" <?php if (!$_POST['catequista'] || $_POST['catequista']=="") echo("selected"); ?>>Todos</option>
+                <option value="" <?php if (!isset($_POST['catequista']) || $_POST['catequista']=="") echo("selected"); ?>>Todos</option>
 	<?php
 
         //Get active catechists
@@ -198,7 +198,7 @@ $menu->renderHTML();
 			foreach($result as $row)
 			{
 				echo("<option value='" . Utils::sanitizeOutput($row['username']) . "'");
-				if ($_SERVER["REQUEST_METHOD"] == "POST" && $_POST['catequista']==$row['username']) 
+                                if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['catequista']) && $_POST['catequista']==$row['username'])
 					echo(" selected");
 				echo(">");
 				echo("" . Utils::sanitizeOutput($row['nome']) . "</option>\n");
@@ -220,22 +220,22 @@ $menu->renderHTML();
   <a style="cursor: pointer;" data-toggle="collapse" data-target="#filtros">Aplicar filtros <span class="glyphicon glyphicon-chevron-down"></span></a>
   <div style="margin-bottom: 10px"></div>
   
-  <div id="filtros" class="collapse <?php if (($_POST['filtro_bap']!='' && $_POST['filtro_bap']!=0) ||($_POST['filtro_com']!='' && $_POST['filtro_com']!=0) || ($_POST['excluir_1']=='on') || ($_POST['excluir_2']=='on') || ($_POST['excluir_3']=='on') || ($_POST['excluir_4']=='on') || ($_POST['excluir_5']=='on') || ($_POST['excluir_6']=='on') || ($_POST['excluir_7']=='on') || ($_POST['excluir_8']=='on') || ($_POST['excluir_9']=='on') || ($_POST['excluir_10']=='on')) echo('in'); ?>">  
+  <div id="filtros" class="collapse <?php if ((isset($_POST['filtro_bap']) && $_POST['filtro_bap']!='' && $_POST['filtro_bap']!=0) || (isset($_POST['filtro_com']) && $_POST['filtro_com']!='' && $_POST['filtro_com']!=0) || (isset($_POST['excluir_1']) && $_POST['excluir_1']=='on') || (isset($_POST['excluir_2']) && $_POST['excluir_2']=='on') || (isset($_POST['excluir_3']) && $_POST['excluir_3']=='on') || (isset($_POST['excluir_4']) && $_POST['excluir_4']=='on') || (isset($_POST['excluir_5']) && $_POST['excluir_5']=='on') || (isset($_POST['excluir_6']) && $_POST['excluir_6']=='on') || (isset($_POST['excluir_7']) && $_POST['excluir_7']=='on') || (isset($_POST['excluir_8']) && $_POST['excluir_8']=='on') || (isset($_POST['excluir_9']) && $_POST['excluir_9']=='on') || (isset($_POST['excluir_10']) && $_POST['excluir_10']=='on')) echo('in'); ?>">
   	<div class="form-group">
    	<div class="col-xs-6">
    		<label for="filtro_bap">Baptismo:</label>
 		<select name="filtro_bap">
-			<option value="0" <?php if (!$_POST['filtro_bap'] || $_POST['filtro_bap']=="" || $_POST['filtro_bap']==0) echo("selected"); ?>>Indiferente</option>
-			<option value="1" <?php if ($_POST['filtro_bap']==1) echo("selected"); ?>>Fez</option>
-			<option value="2" <?php if ($_POST['filtro_bap']==2) echo("selected"); ?>>Não fez</option>
+                        <option value="0" <?php if (!isset($_POST['filtro_bap']) || $_POST['filtro_bap']=="" || $_POST['filtro_bap']==0) echo("selected"); ?>>Indiferente</option>
+                        <option value="1" <?php if (isset($_POST['filtro_bap']) && $_POST['filtro_bap']==1) echo("selected"); ?>>Fez</option>
+                        <option value="2" <?php if (isset($_POST['filtro_bap']) && $_POST['filtro_bap']==2) echo("selected"); ?>>Não fez</option>
 		</select>
 	</div>
 	<div class="col-xs-6">
    		<label for="filtro_com">Primeira comunhão:</label>
 		<select name="filtro_com">
-			<option value="0" <?php if (!$_POST['filtro_com'] || $_POST['filtro_com']=="" || $_POST['filtro_com']==0) echo("selected"); ?>>Indiferente</option>
-			<option value="1" <?php if ($_POST['filtro_com']==1) echo("selected"); ?>>Fez</option>
-			<option value="2" <?php if ($_POST['filtro_com']==2) echo("selected"); ?>>Não fez</option>
+                        <option value="0" <?php if (!isset($_POST['filtro_com']) || $_POST['filtro_com']=="" || $_POST['filtro_com']==0) echo("selected"); ?>>Indiferente</option>
+                        <option value="1" <?php if (isset($_POST['filtro_com']) && $_POST['filtro_com']==1) echo("selected"); ?>>Fez</option>
+                        <option value="2" <?php if (isset($_POST['filtro_com']) && $_POST['filtro_com']==2) echo("selected"); ?>>Não fez</option>
 		</select>
 	</div>
 	</div>
@@ -249,7 +249,7 @@ $menu->renderHTML();
         for($i = 1; $i <= intval(Configurator::getConfigurationValueOrDefault(Configurator::KEY_NUM_CATECHISMS)); $i++)
         {
             ?>
-            <input name="excluir_<?= $i ?>" type="checkbox" <?php if($_POST['excluir_' . $i]=='on') echo('checked'); ?>><?= $i ?>º
+            <input name="excluir_<?= $i ?>" type="checkbox" <?php if(isset($_POST['excluir_' . $i]) && $_POST['excluir_' . $i]=='on') echo('checked'); ?>><?= $i ?>º
             <?php
         }
         ?>
@@ -290,17 +290,17 @@ $menu->renderHTML();
 	if ($_SERVER["REQUEST_METHOD"] == "POST") 
 	{
 		
-		if($_POST['ano_catequetico'])
-			$ano_catequetico = intval($_POST['ano_catequetico']);
-		if($_POST['catequista'])
-			$catequista = Utils::sanitizeInput($_POST['catequista']);
+                if(isset($_POST['ano_catequetico']) && $_POST['ano_catequetico'])
+                        $ano_catequetico = intval($_POST['ano_catequetico']);
+                if(isset($_POST['catequista']) && $_POST['catequista'])
+                        $catequista = Utils::sanitizeInput($_POST['catequista']);
 		if(isset($_POST['filtro_bap']))
 			$bap = intval($_POST['filtro_bap']);
 		if(isset($_POST['filtro_com']))
 			$com = intval($_POST['filtro_com']);
 		for($i = 1; $i <= intval(Configurator::getConfigurationValueOrDefault(Configurator::KEY_NUM_CATECHISMS)); $i++)
         {
-            if($_POST["excluir_" . $i])
+            if(isset($_POST["excluir_" . $i]) && $_POST["excluir_" . $i])
             {
                 array_push($excludedCatechisms, $i);
                 $exclusoes = true;


### PR DESCRIPTION
## Summary
- fix PHP warnings in `pesquisarCatequista.php` by checking POST variables with `isset`

## Testing
- `php -l pesquisarCatequista.php`

------
https://chatgpt.com/codex/tasks/task_e_687fef0900308328a51c4848b92bda43