### PR TITLE
Fix guardar op check

### DIFF
--- a/aproveitamento.php
+++ b/aproveitamento.php
@@ -143,7 +143,7 @@ $evaluationPeriodPanel->handlePost();
 
 
     //Guardar alteracoes
-    if($_REQUEST['op']=="guardar" && $periodo_activo)
+    if (isset($_REQUEST['op']) && $_REQUEST['op'] == "guardar" && $periodo_activo)
     {
         $catequizandos_passam = $_POST['catequizando'];	//Lista de cid de catequizandos que passam
 


### PR DESCRIPTION
## Summary
- add null check for guardar op in `aproveitamento.php`

## Testing
- `php -l aproveitamento.php`

------
https://chatgpt.com/codex/tasks/task_e_687ff29b5584832892bcbef5831cf399