### PR TITLE
Fix undefined index for evaluation switch

### DIFF
--- a/gui/widgets/configuration_panels/CatechumensEvaluationActivationPanel/CatechumensEvaluationActivationPanelWidget.php
+++ b/gui/widgets/configuration_panels/CatechumensEvaluationActivationPanel/CatechumensEvaluationActivationPanelWidget.php
@@ -101,7 +101,7 @@ class CatechumensEvaluationActivationPanelWidget extends AbstractSettingsPanelWi
         //Activar/desactivar
         if($_POST['action'] == self::$ACTION_PARAMETER && Authenticator::isAdmin())
         {
-            $setting = Utils::sanitizeInput($_POST['evaluation_period_switch']);
+            $setting = Utils::sanitizeInput($_POST['evaluation_period_switch'] ?? 'off');
 
             if($setting=="on")
             {


### PR DESCRIPTION
## Summary
- avoid undefined index when evaluation switch is off

## Testing
- `php -l gui/widgets/configuration_panels/CatechumensEvaluationActivationPanel/CatechumensEvaluationActivationPanelWidget.php`


------
https://chatgpt.com/codex/tasks/task_e_687ff49c08708328a83be39330ebb83a