### PR TITLE
Fix array key notice in virtual catechesis form

### DIFF
--- a/criarCatequeseVirtual.php
+++ b/criarCatequeseVirtual.php
@@ -206,7 +206,7 @@ $menu->renderHTML();
         if($catecismo == -1)
             $turma = "_";
     }
-    if($_POST['data_sessao'])
+    if(isset($_POST['data_sessao']) && $_POST['data_sessao'])
     {
         $data_sessao = $_POST['data_sessao']; // sanitizeInput($_POST['data_sessao']);
     }


### PR DESCRIPTION
## Summary
- avoid warning when `data_sessao` is absent in `criarCatequeseVirtual.php`

## Testing
- `php -l criarCatequeseVirtual.php`

------
https://chatgpt.com/codex/tasks/task_e_687ff8696c1c83288c1060469213590b