### PR TITLE
Add basic localization support

### DIFF
--- a/core/Translation.php
+++ b/core/Translation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace catechesis;
+
+require_once(__DIR__ . '/Configurator.php');
+require_once(__DIR__ . '/domain/Locale.php');
+
+use core\domain\Locale;
+
+class Translation
+{
+    private static $translations = null;
+    private static $fallback = null;
+    private static $currentLocale = null;
+
+    public static function t(string $key): string
+    {
+        $locale = Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE);
+        if (self::$translations === null || self::$currentLocale !== $locale) {
+            self::loadLocale($locale);
+        }
+        if (isset(self::$translations[$key])) {
+            return self::$translations[$key];
+        }
+        return self::$fallback[$key] ?? $key;
+    }
+
+    public static function setLocale(string $locale): void
+    {
+        self::loadLocale($locale);
+    }
+
+    private static function loadLocale(string $locale): void
+    {
+        self::$fallback = require(__DIR__ . '/../locale/pt_PT.php');
+        if ($locale === Locale::BRASIL) {
+            $br = require(__DIR__ . '/../locale/pt_BR.php');
+            self::$translations = array_merge(self::$fallback, $br);
+        } else {
+            self::$translations = self::$fallback;
+        }
+        self::$currentLocale = $locale;
+    }
+}

--- a/gui/widgets/configuration_panels/ParishSettingsPanel/ParishSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/ParishSettingsPanel/ParishSettingsPanelWidget.php
@@ -10,12 +10,14 @@ require_once(__DIR__ . '/../../../../core/Utils.php');
 require_once(__DIR__ . '/../../../../core/UserData.php');
 require_once(__DIR__ . '/../../../../core/domain/Locale.php');
 require_once(__DIR__ . '/../../../../core/log_functions.php');
+require_once(__DIR__ . '/../../../../core/Translation.php');
 
 use catechesis\Authenticator;
 use catechesis\PdoDatabaseManager;
 use catechesis\Configurator;
 use catechesis\UserData;
 use catechesis\Utils;
+use catechesis\Translation;
 use core\domain\Locale;
 use uLogin;
 
@@ -339,6 +341,7 @@ class ParishSettingsPanelWidget extends AbstractSettingsPanelWidget
                 Configurator::setConfigurationValue(Configurator::KEY_PARISH_PLACE, $editParishPlace);
                 Configurator::setConfigurationValue(Configurator::KEY_PARISH_DIOCESE, $editParishDiocese);
                 Configurator::setConfigurationValue(Configurator::KEY_LOCALIZATION_CODE, $editLocale);
+                Translation::setLocale($editLocale);
                 Configurator::setConfigurationValue(Configurator::KEY_PARISH_CUSTOM_TABLE_FOOTER, $editParishCustomFooter);
 
                 writeLogEntry("Modificou os dados da paróquia.");

--- a/index.php
+++ b/index.php
@@ -5,10 +5,12 @@ require_once(__DIR__ . '/gui/widgets/WidgetManager.php');
 require_once(__DIR__ . '/gui/widgets/Footer/SimpleFooter.php');
 require_once(__DIR__ . '/core/check_maintenance_mode.php'); //Check if maintenance mode is active and redirect visitor
 require_once(__DIR__ . '/core/session_init.php');
+require_once(__DIR__ . '/core/Translation.php');
 
 use catechesis\Configurator;
 use catechesis\gui\WidgetManager;
 use catechesis\gui\SimpleFooter;
+use catechesis\Translation;
 
 // Instantiate a widget manager
 $pageUI = new WidgetManager();
@@ -91,14 +93,14 @@ $pageUI->addWidget($footer);
                         </div>
                         <div class="col-md-6 vertical-align-center">
                             <div class="valign-center">
-                                <h2 class="card-title">Inscrições Online</h2>
+                                <h2 class="card-title"><?= Translation::t('online_enrollments') ?></h2>
                                 <span><strong>Inscrição</strong> na catequese ou <strong>renovação</strong> de matrícula.</span><br>
                                 <span><strong>Consulta</strong> do estado do pedido de incrição ou renovação.</span>
                             </div>
                         </div>
                         <div class="col-md-3 vertical-align-center">
                             <div class="valign-center">
-                                <button type="button" class="btn btn-primary card-button" onclick="goto_online_enrollments();">Ir para Inscrições Online</button>
+                                <button type="button" class="btn btn-primary card-button" onclick="goto_online_enrollments();"><?= Translation::t('go_to_online_enrollments') ?></button>
                             </div>
                         </div>
                     </div>
@@ -116,14 +118,14 @@ $pageUI->addWidget($footer);
                         </div>
                         <div class="col-md-6 vertical-align-center">
                             <div class="valign-center">
-                                <h2 class="card-title">Catequese Virtual</h2>
+                                <h2 class="card-title"><?= Translation::t('virtual_catechesis') ?></h2>
                                 <span>Acesso a <strong>conteúdos</strong> digitais.</span><br>
                                 <span>Dinamização de catequeses à distância, por <strong>videochamada</strong>.</span>
                             </div>
                         </div>
                         <div class="col-md-3 vertical-align-center">
                             <div class="valign-center">
-                                <button type="button" class="btn btn-primary card-button" onclick="goto_virtual_catechesis();">Ir para Catequese Virtual</button>
+                                <button type="button" class="btn btn-primary card-button" onclick="goto_virtual_catechesis();"><?= Translation::t('go_to_virtual_catechesis') ?></button>
                             </div>
                         </div>
                     </div>

--- a/locale/pt_BR.php
+++ b/locale/pt_BR.php
@@ -1,0 +1,13 @@
+<?php
+$lang = [
+    'online_enrollments' => 'Inscrições Online',
+    'go_to_online_enrollments' => 'Ir para Inscrições Online',
+    'virtual_catechesis' => 'Catequese Virtual',
+    'go_to_virtual_catechesis' => 'Ir para Catequese Virtual',
+    'welcome_catechesis_virtual' => 'Bem-vindo à <span class="catequese-virtual-destaque">Catequese Virtual!</span>',
+    'welcome_catechesis' => 'Bem-vindo ao CatecheSis!',
+    'welcome_enrollment_platform' => 'Bem-vindo à plataforma de inscrições da catequese da %s!',
+    'login_button' => 'Iniciar sessão'
+    ,'welcome_update_assistant' => 'Bem-vindo ao assistente de atualização do CatecheSis!'
+];
+return $lang;

--- a/locale/pt_PT.php
+++ b/locale/pt_PT.php
@@ -1,0 +1,13 @@
+<?php
+$lang = [
+    'online_enrollments' => 'Inscrições Online',
+    'go_to_online_enrollments' => 'Ir para Inscrições Online',
+    'virtual_catechesis' => 'Catequese Virtual',
+    'go_to_virtual_catechesis' => 'Ir para Catequese Virtual',
+    'welcome_catechesis_virtual' => 'Bem-vindo à <span class="catequese-virtual-destaque">Catequese Virtual!</span>',
+    'welcome_catechesis' => 'Bem-vindo ao CatecheSis!',
+    'welcome_enrollment_platform' => 'Bem-vindo à plataforma de inscrições da catequese da %s!',
+    'login_button' => 'Iniciar sessão'
+    ,'welcome_update_assistant' => 'Bem-vindo ao assistente de atualização do CatecheSis!'
+];
+return $lang;

--- a/login.php
+++ b/login.php
@@ -5,6 +5,7 @@ require_once(__DIR__ . '/core/Configurator.php');
 require_once(__DIR__ . '/core/Fortune.php');
 require_once(__DIR__ . '/core/DataValidationUtils.php');
 require_once(__DIR__ . '/core/Utils.php');
+require_once(__DIR__ . '/core/Translation.php');
 require_once(__DIR__ . '/gui/widgets/WidgetManager.php');
 require_once(__DIR__ . '/gui/widgets/Footer/SimpleFooter.php');
 require_once(__DIR__ . '/core/check_maintenance_mode.php'); //Check if maintenance mode is active and redirect visitor
@@ -16,6 +17,7 @@ use catechesis\DataValidationUtils;
 use catechesis\Utils;
 use catechesis\gui\WidgetManager;
 use catechesis\gui\SimpleFooter;
+use catechesis\Translation;
 
 if (!defined('CATECHESIS_BASE_URL')) {
     define('CATECHESIS_BASE_URL', '/catechesis');
@@ -194,7 +196,7 @@ $pageUI->addWidget($footer);
                 <div id="right-form" class="col-md-6">
                     <div class="row" style="margin-bottom: 80px;"></div>
                     <h1>Entrar</h1>
-                    <h2>Bem-vindo ao CatecheSis!</h2>
+                    <h2><?= Translation::t('welcome_catechesis') ?></h2>
 
                     <form class="form-horizontal" role="form" action="login.php" method="post" onsubmit="onSubmit()">
                         <div class="input_box">
@@ -234,7 +236,7 @@ $pageUI->addWidget($footer);
                         }
                         ?>
 
-                        <button id="login_button" type="submit" class="btn btn-primary"><strong>Iniciar sessão</strong></button>
+                        <button id="login_button" type="submit" class="btn btn-primary"><strong><?= Translation::t('login_button') ?></strong></button>
                     </form>
 
                     <div class="row" style="margin-bottom: 80px;"></div>
@@ -266,7 +268,7 @@ $footer->renderHTML();
     function onSubmit()
     {
         var login_button = document.getElementById("login_button");
-        login_button.innerHTML = '<i class="fas fa-spinner fa-pulse"></i>&nbsp; Iniciar sessão';
+        login_button.innerHTML = '<i class="fas fa-spinner fa-pulse"></i>&nbsp; ' + <?= json_encode(Translation::t('login_button')) ?>;
         login_button.disabled = true;
     }
 </script>

--- a/publico/inscricoes.php
+++ b/publico/inscricoes.php
@@ -6,6 +6,7 @@ require_once(__DIR__ . '/../gui/widgets/WidgetManager.php');
 require_once(__DIR__ . '/../gui/widgets/Navbar/MinimalNavbar.php');
 require_once(__DIR__ . '/../gui/widgets/Footer/SimpleFooter.php');
 require_once(__DIR__ . '/../core/check_maintenance_mode.php'); //Check if maintenance mode is active and redirect visitor
+require_once(__DIR__ . '/../core/Translation.php');
 
 
 use catechesis\Configurator;
@@ -13,6 +14,7 @@ use catechesis\Utils;
 use catechesis\gui\WidgetManager;
 use catechesis\gui\MinimalNavbar;
 use catechesis\gui\SimpleFooter;
+use catechesis\Translation;
 
 
 //Verificar se o periodo de inscricoes esta ativo
@@ -74,7 +76,7 @@ $navbar->renderHTML();
     if($periodo_activo)
     {
     ?>
-        <p>Bem-vindo à plataforma de inscrições da catequese da <?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_PARISH_NAME); ?>!<br>
+        <p><?= sprintf(Translation::t('welcome_enrollment_platform'), Configurator::getConfigurationValueOrDefault(Configurator::KEY_PARISH_NAME)); ?><br>
         Selecione a opção que melhor se ajusta ao seu caso:</p>
 
 
@@ -106,7 +108,7 @@ $navbar->renderHTML();
     {
     ?>
 
-    <p>Bem-vindo à plataforma de inscrições da catequese da <?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_PARISH_NAME); ?>!<br>
+    <p><?= sprintf(Translation::t('welcome_enrollment_platform'), Configurator::getConfigurationValueOrDefault(Configurator::KEY_PARISH_NAME)); ?><br>
         De momento, as inscrições estão fechadas. Se desejar efetuar uma inscrição ou renovação de matrícula, contacte a catequese.</p>
 
     <div class="row" style="margin-top: 40px"></div>

--- a/updater/index.php
+++ b/updater/index.php
@@ -10,6 +10,7 @@ require_once(__DIR__ . '/Checker.php');
 require_once(__DIR__ . '/utils.php');
 require_once(__DIR__ . '/../core/UpdateChecker.php');
 require_once(__DIR__ . '/../core/log_functions.php');
+require_once(__DIR__ . '/../core/Translation.php');
 
 
 use catechesis\DataValidationUtils;
@@ -20,6 +21,7 @@ use MirazMac\Requirements\Checker;
 use catechesis\PdoDatabaseManager;
 use catechesis\Configurator;
 use catechesis\Authenticator;
+use catechesis\Translation;
 
 
 if(!Authenticator::isAdmin())
@@ -317,7 +319,7 @@ $_SESSION['setup_step'] = $current_step;
                         <form class="form-horizontal" id="form-wizard" role="form" action="index.php" method="post">
 
                             <h1>Atualização</h1>
-                            <h2>Bem-vindo ao assistente de atualização do CatecheSis!</h2>
+                            <h2><?= Translation::t('welcome_update_assistant') ?></h2>
 
                             <?php
                             if($updateChecker->isUpdateAvailable())

--- a/virtual/index.php
+++ b/virtual/index.php
@@ -9,6 +9,7 @@ require_once(__DIR__ . '/../fonts/quill-fonts.php');
 require_once(__DIR__ . '/../gui/widgets/WidgetManager.php');
 require_once(__DIR__ . '/../gui/widgets/Footer/SimpleFooter.php');
 require_once(__DIR__ . '/../core/check_maintenance_mode.php'); //Check if maintenance mode is active and redirect visitor
+require_once(__DIR__ . '/../core/Translation.php');
 
 
 use catechesis\Authenticator;
@@ -18,6 +19,7 @@ use catechesis\PdoDatabaseManager;
 use catechesis\Utils;
 use catechesis\gui\WidgetManager;
 use catechesis\gui\SimpleFooter;
+use catechesis\Translation;
 
 // Start a secure session if none is running
 Authenticator::startSecureSession();
@@ -301,7 +303,7 @@ $pageUI->addWidget($footer);
 
                             <div id="block-title">
                                 <h3>Novos desafios exigem novas respostas!</h3>
-                                <h1>Bem-vindo à <span class="catequese-virtual-destaque">Catequese Virtual!</span></h1>
+                                <h1><?= Translation::t('welcome_catechesis_virtual') ?></h1>
                             </div>
 
                             <div class="row" style="margin-bottom: 80px"></div>


### PR DESCRIPTION
## Summary
- create Portuguese locale files for Portugal and Brazil
- implement `Translation` helper class with locale fallback logic
- use `Translation::t()` in pages and widgets
- reload locale when parish settings change

## Testing
- `php -l core/Translation.php`
- `php -l index.php`
- `php -l login.php`
- `php -l publico/inscricoes.php`
- `php -l virtual/index.php`
- `php -l updater/index.php`
- `php -l gui/widgets/configuration_panels/ParishSettingsPanel/ParishSettingsPanelWidget.php`

------
https://chatgpt.com/codex/tasks/task_e_687ffe63b1208328b0f7bc35b3124261