### PR TITLE
Add locale-aware language and date settings

### DIFF
--- a/analisarComunhoes.php
+++ b/analisarComunhoes.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -32,7 +33,7 @@ $pageUI->addWidget($reportWidget);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Apoio à decisão -- Primeiras Comunhões</title>
   <meta charset="utf-8">

--- a/analisarCrismas.php
+++ b/analisarCrismas.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -32,7 +33,7 @@ $pageUI->addWidget($reportWidget);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <title>Apoio à decisão -- Crismas</title>
     <meta charset="utf-8">

--- a/aproveitamento.php
+++ b/aproveitamento.php
@@ -34,7 +34,7 @@ $pageUI->addWidget($evaluationPeriodPanel);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Aproveitamento</title>
   <meta charset="utf-8">

--- a/configuracoes.php
+++ b/configuracoes.php
@@ -77,7 +77,7 @@ if($action == UserAccountConfigurationPanelWidget::$ACTION_PARAMETER)
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Configurações</title>
   <meta charset="utf-8">

--- a/core/document_generators/templateGDPR.php
+++ b/core/document_generators/templateGDPR.php
@@ -14,7 +14,7 @@ $dpoAddress = Configurator::getConfigurationValueOrDefault(Configurator::KEY_GDP
 $dpoEmail = Configurator::getConfigurationValueOrDefault(Configurator::KEY_GDPR_DPO_EMAIL);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <meta charset="UTF-8" />
     <title>Declaração de consentimento</title>

--- a/core/domain/Locale.php
+++ b/core/domain/Locale.php
@@ -9,6 +9,26 @@ abstract class Locale
     const PORTUGAL = "PT";
     const BRASIL = "BR";
 
+    /**
+     * Returns the appropriate language tag to be used in the HTML
+     * lang attribute for the provided locale.
+     *
+     * @param string $locale Country code as stored in configuration
+     * @return string Language tag (e.g. "pt" or "pt-br")
+     */
+    public static function htmlLang(string $locale)
+    {
+        switch($locale)
+        {
+            case self::BRASIL:
+                return "pt-br";
+
+            case self::PORTUGAL:
+            default:
+                return "pt";
+        }
+    }
+
 
     public static function catechesisStartMonth(string $locale)
     {

--- a/criarCatequeseVirtual.php
+++ b/criarCatequeseVirtual.php
@@ -42,7 +42,7 @@ $pageUI->addWidget($saveDialog);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Criar catequese virtual</title>
   <meta charset="utf-8">
@@ -501,7 +501,10 @@ $pageUI->renderJS(); // Render the widgets' JS code
 quill_render_js_scripts();
 ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
-<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<?php
+    $dpLocale = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt-BR' : 'pt';
+?>
+<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.<?= $dpLocale ?>.min.js"></script>
 <script src="js/rowlink.js"></script>
 <script src="js/quill-1.3.6/quill.min.js"></script>
 <script src="js/quill-image-resize-module/image-resize.min.js"></script>

--- a/criarUtilizador.php
+++ b/criarUtilizador.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -24,7 +25,7 @@ $pageUI->addWidget($menu);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Gerir utilizadores e catequistas</title>
   <meta charset="utf-8">

--- a/dadosInconsistentes.php
+++ b/dadosInconsistentes.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -32,7 +33,7 @@ $pageUI->addWidget($reportWidget);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Dados inconsistentes</title>
   <meta charset="utf-8">

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/Authenticator.php');
@@ -48,7 +49,7 @@ $pageUI->addWidget($quickAccess);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Início</title>
   <meta charset="utf-8">

--- a/eliminarFicha.php
+++ b/eliminarFicha.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -31,7 +32,7 @@ $menu = new MainNavbar(null, MENU_OPTION::CATECHUMENS);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Detalhes do catequizando</title>
   <meta charset="utf-8">

--- a/erro404.php
+++ b/erro404.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/authentication/Authenticator.php');
 require_once(__DIR__ . "/gui/widgets/WidgetManager.php");
@@ -34,7 +35,7 @@ else
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>CatecheSis - Recurso não encontrado</title>
   <meta charset="utf-8">

--- a/erro500.php
+++ b/erro500.php
@@ -1,8 +1,9 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>CatecheSis - Erro interno</title>
   <meta charset="utf-8">

--- a/estatisticaDesistencias.php
+++ b/estatisticaDesistencias.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -21,7 +22,7 @@ $menu = new MainNavbar(null, MENU_OPTION::ANALYSIS);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Estatísticas</title>
   <meta charset="utf-8">

--- a/estatisticaNumCatequizandos.php
+++ b/estatisticaNumCatequizandos.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -21,7 +22,7 @@ $menu = new MainNavbar(null, MENU_OPTION::ANALYSIS);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Estatísticas</title>
   <meta charset="utf-8">

--- a/estatisticaPercursosCompletos.php
+++ b/estatisticaPercursosCompletos.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -23,7 +24,7 @@ $pageUI->addWidget($menu);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Estatísticas</title>
   <meta charset="utf-8">

--- a/estatisticaResidentes.php
+++ b/estatisticaResidentes.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -21,7 +22,7 @@ $pageUI->addWidget($menu);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Estatísticas</title>
   <meta charset="utf-8">

--- a/fichasCatequizandos.php
+++ b/fichasCatequizandos.php
@@ -40,7 +40,7 @@ $pageUI->addWidget($printDialog);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Fichas dos catequizandos</title>
   <meta charset="utf-8">

--- a/fichasPreInscricao.php
+++ b/fichasPreInscricao.php
@@ -26,7 +26,7 @@ $menu = new MainNavbar(null, MENU_OPTION::CATECHESIS);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Fichas de pré-inscrição</title>
   <meta charset="utf-8">

--- a/folhasPresencas.php
+++ b/folhasPresencas.php
@@ -43,7 +43,7 @@ $pageUI->addWidget($printDialog);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Folha de presenças</title>
   <meta charset="utf-8">
@@ -219,7 +219,8 @@ $menu->renderHTML();
         $weekDay = WeekDay::toString(Configurator::getConfigurationValueOrDefault(Configurator::KEY_CATECHESIS_WEEK_DAY));
 		$timestamp = strtotime('first ' . $weekDay . ' of ' . Locale::catechesisStartMonth(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)), strtotime('1-1-' . $ano_i));
 
-		setlocale(LC_TIME, "pt_PT");
+            $localeCode = (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt_BR' : 'pt_PT';
+            setlocale(LC_TIME, $localeCode);
 		$mes_actual = strftime('%m', $timestamp);
 		$ultimo_mes = strftime('%m', $timestamp);
 	
@@ -256,7 +257,8 @@ $menu->renderHTML();
 		
 		$timestamp = strtotime('first ' . $weekDay . ' of ' . $months[intval($mes)], strtotime('1-1-' . $ano));
 
-		setlocale(LC_TIME, "pt_PT");
+                $localeCode = (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt_BR' : 'pt_PT';
+                setlocale(LC_TIME, $localeCode);
 		$mes_actual = strftime('%m', $timestamp);
 		$ultimo_mes = strftime('%m', $timestamp);
 		

--- a/gerarFolhasPresencas.php
+++ b/gerarFolhasPresencas.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -22,7 +23,7 @@ $menu = new MainNavbar(null, MENU_OPTION::CATECHESIS);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Área de Impressão</title>
   <meta charset="utf-8">

--- a/gerirGrupos.php
+++ b/gerirGrupos.php
@@ -37,7 +37,7 @@ $pageUI->addWidget($catechistAvailabilityDialog);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Gerir grupos de catequese</title>
   <meta charset="utf-8">

--- a/gerirUtilizadores.php
+++ b/gerirUtilizadores.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -44,7 +45,7 @@ $pageUI->addWidget($userAccountSettingsPanel);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Gerir utilizadores e catequistas</title>
   <meta charset="utf-8">

--- a/gui/widgets/SacramentRecordPanel/SacramentRecordPanelWidget.php
+++ b/gui/widgets/SacramentRecordPanel/SacramentRecordPanelWidget.php
@@ -48,7 +48,8 @@ class SacramentRecordPanelWidget extends AbstractSettingsPanelWidget
         $this->addCSSDependency('css/jquery.fileupload.css');
         $this->addCSSDependency('css/dropzone.css');
         $this->addJSDependency('js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js');
-        $this->addJSDependency('js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js');
+        $dpLocale = (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt-BR' : 'pt';
+        $this->addJSDependency("js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.$dpLocale.min.js");
         $this->addJSDependency('js/jquery.ui.widget.js');
         $this->addJSDependency('js/jquery.iframe-transport.js');    //The Iframe Transport is required for browsers without support for XHR file uploads
         $this->addJSDependency('js/jquery.fileupload.js');          //The basic File Upload plugin

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/inscricao.php
+++ b/inscricao.php
@@ -37,7 +37,7 @@ $db = new PdoDatabaseManager();
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>
   	<?php
@@ -597,7 +597,10 @@ $menu->renderHTML();
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
-<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<?php
+    $dpLocale = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt-BR' : 'pt';
+?>
+<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.<?= $dpLocale ?>.min.js"></script>
 <script type="text/javascript" src="webcamjs-master/webcam.js"></script>
 
 <script language="JavaScript">    

--- a/listarBaptismos.php
+++ b/listarBaptismos.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -34,7 +35,7 @@ $pageUI->addWidget($listingResults);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Listar Baptismos</title>
   <meta charset="utf-8">

--- a/listarComunhoes.php
+++ b/listarComunhoes.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -34,7 +35,7 @@ $pageUI->addWidget($listingResults);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Listar Primeiras Comunhões</title>
   <meta charset="utf-8">

--- a/listarConfirmacoes.php
+++ b/listarConfirmacoes.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -34,7 +35,7 @@ $pageUI->addWidget($listingResults);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Listar Crismas</title>
   <meta charset="utf-8">

--- a/listarEscuteiros.php
+++ b/listarEscuteiros.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -34,7 +35,7 @@ $pageUI->addWidget($searchResults);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Listar escuteiros</title>
   <meta charset="utf-8">

--- a/listarProfissoesFe.php
+++ b/listarProfissoesFe.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -34,7 +35,7 @@ $pageUI->addWidget($listingResults);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Listar Profissões de Fé</title>
   <meta charset="utf-8">

--- a/logAutenticacoes.php
+++ b/logAutenticacoes.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -23,7 +24,7 @@ $menu = new MainNavbar(null, MENU_OPTION::ANALYSIS);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Registos de actividade do sistema</title>
   <meta charset="utf-8">

--- a/logCatechesis.php
+++ b/logCatechesis.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -23,7 +24,7 @@ $menu = new MainNavbar(null, MENU_OPTION::ANALYSIS);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Registos de actividade do sistema</title>
   <meta charset="utf-8">

--- a/login.php
+++ b/login.php
@@ -136,7 +136,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/meusCatequizandos.php
+++ b/meusCatequizandos.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
@@ -64,7 +65,7 @@ if($result && count($result) > 0)
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Os meus catequizandos</title>
   <meta charset="utf-8">

--- a/mostrarArquivo.php
+++ b/mostrarArquivo.php
@@ -59,7 +59,7 @@ $pageUI->addWidget($chrismationPanel);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Detalhes do catequizando</title>
   <meta charset="utf-8">

--- a/mostrarAutorizacoes.php
+++ b/mostrarAutorizacoes.php
@@ -40,7 +40,7 @@ $pageUI->addWidget($deleteFamilyMemberDialog);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Detalhes do catequizando</title>
   <meta charset="utf-8">

--- a/mostrarFicha.php
+++ b/mostrarFicha.php
@@ -40,7 +40,7 @@ $pageUI->addWidget($deleteDialog);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Detalhes do catequizando</title>
   <meta charset="utf-8">

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -33,7 +33,7 @@ $pageUI->addWidget($menu);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Pedido de inscrição</title>
   <meta charset="utf-8">
@@ -748,7 +748,10 @@ if(!isset($submission['cid']))
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
-<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<?php
+    $dpLocale = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt-BR' : 'pt';
+?>
+<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.<?= $dpLocale ?>.min.js"></script>
 
 <script>
 function validar()

--- a/novoAno.php
+++ b/novoAno.php
@@ -200,7 +200,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Gerir grupos de catequese</title>
   <meta charset="utf-8">

--- a/pagamentos.php
+++ b/pagamentos.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
 require_once(__DIR__ . '/authentication/Authenticator.php');
@@ -53,7 +54,7 @@ try {
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
 
   <title>Pagamentos</title>

--- a/pesquisarAno.php
+++ b/pesquisarAno.php
@@ -34,7 +34,7 @@ $pageUI->addWidget($searchResults);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Pesquisar catequizandos</title>
   <meta charset="utf-8">

--- a/pesquisarCatequista.php
+++ b/pesquisarCatequista.php
@@ -33,7 +33,7 @@ $pageUI->addWidget($searchResults);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Pesquisar catequizandos</title>
   <meta charset="utf-8">

--- a/pesquisarNome.php
+++ b/pesquisarNome.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/Configurator.php');
 require_once(__DIR__ . "/core/config/catechesis_config.inc.php");
 require_once(__DIR__ . "/authentication/utils/authentication_verify.php");
 require_once(__DIR__ . "/core/Utils.php");
@@ -36,7 +37,7 @@ $pageUI->addWidget($searchResults);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Pesquisar catequizandos</title>
   <meta charset="utf-8">
@@ -229,7 +230,10 @@ $longSearchWarning->renderHTML();
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
-<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<?php
+    $dpLocale = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt-BR' : 'pt';
+?>
+<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.<?= $dpLocale ?>.min.js"></script>
 <script src="js/form-validation-utils.js"></script>
 <script src="js/rowlink.js"></script>
 

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -42,7 +42,7 @@ $menu = new MainNavbar(null, MENU_OPTION::ENROLMENTS, true);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>
       <?php

--- a/processarInscricoesOnline.php
+++ b/processarInscricoesOnline.php
@@ -46,7 +46,7 @@ $pageUI->addWidget($orderDetailsDialog);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <title>Processar pedidos de inscrição</title>
     <meta charset="utf-8">

--- a/publico/consultarPedido.php
+++ b/publico/consultarPedido.php
@@ -44,7 +44,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <meta charset="UTF-8">
     <title>Estado do pedido de inscrição na catequese</title>

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -66,7 +66,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Inscrição na catequese</title>
   <meta charset="utf-8">

--- a/publico/doRenovarMatricula.php
+++ b/publico/doRenovarMatricula.php
@@ -50,7 +50,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <meta charset="UTF-8">
     <title>Renovação de matrícula</title>

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -52,7 +52,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>
   	<?php
@@ -666,7 +666,10 @@ $footer->renderHTML();
 
 <?php $pageUI->renderJS(); ?>
 <script src="../js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
-<script src="../js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<?php
+    $dpLocale = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt-BR' : 'pt';
+?>
+<script src="../js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.<?= $dpLocale ?>.min.js"></script>
 <script type="text/javascript" src="../webcamjs-master/webcam.js"></script>
 <script src="../js/form-validation-utils.js"></script>
 

--- a/publico/inscricoes.php
+++ b/publico/inscricoes.php
@@ -36,7 +36,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <meta charset="UTF-8">
     <title>Inscrição na catequese</title>

--- a/publico/renovarMatricula.php
+++ b/publico/renovarMatricula.php
@@ -49,7 +49,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <meta charset="UTF-8">
     <title>Renovação de matrícula</title>

--- a/registarSacramentos.php
+++ b/registarSacramentos.php
@@ -31,7 +31,7 @@ $menu = new MainNavbar(null, MENU_OPTION::SACRAMENTS);
 $pageUI->addWidget($menu);
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Registar sacramentos</title>
   <meta charset="utf-8">
@@ -598,7 +598,10 @@ if(Authenticator::isAdmin() || group_belongs_to_catechist($ano_precedente, $cate
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
-<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<?php
+    $dpLocale = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt-BR' : 'pt';
+?>
+<script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.<?= $dpLocale ?>.min.js"></script>
 <script src="js/rowlink.js"></script>
 <script src="js/bootstrap-switch.js"></script>
 

--- a/renovacaoMatriculas.php
+++ b/renovacaoMatriculas.php
@@ -41,7 +41,7 @@ $pageUI->addWidget($renewalDetailsDialog);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
   <title>Renovação de matrículas</title>
   <meta charset="utf-8">

--- a/updater/index.php
+++ b/updater/index.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/../core/Configurator.php');
 require_once(__DIR__ . '/../core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/../authentication/utils/authentication_verify.php');
 require_once(__DIR__ . '/../authentication/Authenticator.php');
@@ -228,7 +229,7 @@ $_SESSION['setup_step'] = $current_step;
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/virtual/index.php
+++ b/virtual/index.php
@@ -32,7 +32,7 @@ $pageUI->addWidget($footer);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="<?php echo \core\domain\Locale::htmlLang(\catechesis\Configurator::getConfigurationValueOrDefault(catechesis\Configurator::KEY_LOCALIZATION_CODE)); ?>">
 <head>
     <title>Catequese Virtual</title>
     <meta charset="utf-8">
@@ -253,7 +253,8 @@ $pageUI->addWidget($footer);
 
                 <h2><?= $catecismo ?>º Catecismo <?php if(isset($turma) && $turma !== "" && $turma !== "_") echo(" - Grupo $turma");?></h2>
                 <h4><?php
-                    setlocale(LC_TIME, 'pt_PT', 'pt_PT.utf-8', 'pt_PT.utf-8', 'portuguese');
+                    $localeCode = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt_BR' : 'pt_PT';
+                    setlocale(LC_TIME, $localeCode, $localeCode.'.utf-8', $localeCode.'.utf8', 'portuguese');
                     echo(Utils::toUTF8(strftime('%A, %d de %B de %Y', strtotime($data_sessao))));
                     //echo(strftime('%A, %d de %B de %Y', strtotime($data_sessao))); //Usar este se o de cima der problemas de encoding
                     ?></h4>
@@ -367,7 +368,10 @@ if($on_landing_page)
 <script src="../js/quill-1.3.6/quill.min.js"></script>
 <script src="../js/quill-image-resize-module/image-resize.min.js"></script>
 <script src="../js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
-<script src="../js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<?php
+    $dpLocale = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? 'pt-BR' : 'pt';
+?>
+<script src="../js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.<?= $dpLocale ?>.min.js"></script>
 
 <script>
     $(document).ready(function () {


### PR DESCRIPTION
## Summary
- add `Locale::htmlLang` helper
- use locale to set `<html lang>`
- load correct datepicker locale
- adjust locale when formatting dates
- include Configurator where needed

## Testing
- `php -l core/domain/Locale.php`
- `php -l login.php`
- `php -l virtual/index.php`
- `php -l folhasPresencas.php`
- `php -l inscricao.php`
- `php -l updater/index.php`
- `php -l analisarBaptismos.php`


------
https://chatgpt.com/codex/tasks/task_e_687ffe65ef7c8328a542c3e1802cc24c