### PR TITLE
Implement timezone-aware greetings

### DIFF
--- a/core/Utils.php
+++ b/core/Utils.php
@@ -618,17 +618,27 @@ class Utils
      */
     public static function greeting($username): string
     {
-        date_default_timezone_set('Europe/Lisbon'); //FIXME Make this a configurable setting
+        $locale = Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE);
+        switch ($locale) {
+            case Locale::BRASIL:
+                date_default_timezone_set('America/Sao_Paulo');
+                break;
+            case Locale::PORTUGAL:
+            default:
+                date_default_timezone_set('Europe/Lisbon');
+                break;
+        }
+
         $hour = date('H');
 
-        if($hour >= 2 && $hour < 7)
-            return "A madrugar, $username?";
-        else if($hour >= 7 && $hour < 12)
-            return "Bom dia, $username!";
-        else if($hour >= 12 && $hour < 20)
-            return "Boa tarde, $username!";
-        else if($hour >= 20 || $hour < 2)
-            return "Boa noite, $username!";
+        if ($hour >= 2 && $hour < 7)
+            return sprintf(Translation::t('greeting_early'), $username);
+        else if ($hour >= 7 && $hour < 12)
+            return sprintf(Translation::t('greeting_morning'), $username);
+        else if ($hour >= 12 && $hour < 20)
+            return sprintf(Translation::t('greeting_afternoon'), $username);
+        else if ($hour >= 20 || $hour < 2)
+            return sprintf(Translation::t('greeting_evening'), $username);
     }
 
 

--- a/locale/pt_BR.php
+++ b/locale/pt_BR.php
@@ -9,5 +9,9 @@ $lang = [
     'welcome_enrollment_platform' => 'Bem-vindo à plataforma de inscrições da catequese da %s!',
     'login_button' => 'Iniciar sessão'
     ,'welcome_update_assistant' => 'Bem-vindo ao assistente de atualização do CatecheSis!'
+    ,'greeting_early' => 'A madrugar, %s?'
+    ,'greeting_morning' => 'Bom dia, %s!'
+    ,'greeting_afternoon' => 'Boa tarde, %s!'
+    ,'greeting_evening' => 'Boa noite, %s!'
 ];
 return $lang;

--- a/locale/pt_PT.php
+++ b/locale/pt_PT.php
@@ -9,5 +9,9 @@ $lang = [
     'welcome_enrollment_platform' => 'Bem-vindo à plataforma de inscrições da catequese da %s!',
     'login_button' => 'Iniciar sessão'
     ,'welcome_update_assistant' => 'Bem-vindo ao assistente de atualização do CatecheSis!'
+    ,'greeting_early' => 'A madrugar, %s?'
+    ,'greeting_morning' => 'Bom dia, %s!'
+    ,'greeting_afternoon' => 'Boa tarde, %s!'
+    ,'greeting_evening' => 'Boa noite, %s!'
 ];
 return $lang;


### PR DESCRIPTION
## Summary
- localize greetings in locale files
- make greeting timezone-aware and use Translation

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68800fbd49bc8328b64a0d6834233b99