### PR TITLE
Add DataTables Brazilian Portuguese support

### DIFF
--- a/gui/widgets/CatechumensList/CatechumensListWidget.php
+++ b/gui/widgets/CatechumensList/CatechumensListWidget.php
@@ -318,7 +318,7 @@ class CatechumensListWidget extends AbstractCatechumensListingWidget
                     paging: false,
                     info: false,
                     language: {
-                        url: 'js/DataTables/Portuguese.json'
+                        url: '<?= (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? "js/DataTables/Portuguese-BR.json" : "js/DataTables/Portuguese.json" ?>'
                     },
                     "aaSorting": [], //Do not sort anything at start, to keep the provided order (only when the user clicks on a column),
                     "columnDefs": [

--- a/gui/widgets/CatechumensReport/CatechumensReportWidget.php
+++ b/gui/widgets/CatechumensReport/CatechumensReportWidget.php
@@ -458,7 +458,7 @@ class CatechumensReportWidget extends AbstractCatechumensListingWidget
                                 paging: false,
                                 info: false,
                                 language: {
-                                    url: 'js/DataTables/Portuguese.json'
+                                    url: '<?= (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? "js/DataTables/Portuguese-BR.json" : "js/DataTables/Portuguese.json" ?>'
                                 },
                                 "dom": '<"wrapper"<"col-sm-12" f> lipt>', //Customizations to make the table fill the accordion wihtout padding
                                 "aaSorting": [], //Do not sort anything at start, to keep the provided order (only when the user clicks on a column),

--- a/gui/widgets/SacramentList/SacramentListWidget.php
+++ b/gui/widgets/SacramentList/SacramentListWidget.php
@@ -201,7 +201,7 @@ class SacramentListWidget extends AbstractCatechumensListingWidget
                         paging: false,
                         info: false,
                         language: {
-                            url: 'js/DataTables/Portuguese.json'
+                            url: '<?= (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL) ? "js/DataTables/Portuguese-BR.json" : "js/DataTables/Portuguese.json" ?>'
                         },
                         "aaSorting": [], //Do not sort anything at start, to keep the provided order (only when the user clicks on a column),
                         "columnDefs": [

--- a/js/DataTables/Portuguese-BR.json
+++ b/js/DataTables/Portuguese-BR.json
@@ -1,0 +1,25 @@
+
+
+{
+	"sEmptyTable":   "Não foi encontrado nenhum registro",
+	"sLoadingRecords": "Carregando...",
+	"sProcessing":   "Processando...",
+	"sLengthMenu":   "Mostrar _MENU_ registros",
+	"sZeroRecords":  "Não foram encontrados resultados",
+	"sInfo":         "Mostrando de _START_ até _END_ de _TOTAL_ registros",
+	"sInfoEmpty":    "Mostrando de 0 até 0 de 0 registros",
+	"sInfoFiltered": "(filtrado de _MAX_ registros no total)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Filtrar:",
+	"sUrl":          "",
+	"oPaginate": {
+	    "sFirst":    "Primeiro",
+	    "sPrevious": "Anterior",
+	    "sNext":     "Próximo",
+	    "sLast":     "Último"
+	},
+	"oAria": {
+	    "sSortAscending":  ": Ordenar colunas de forma ascendente",
+	    "sSortDescending": ": Ordenar colunas de forma descendente"
+	}
+}

--- a/processarInscricoesOnline.php
+++ b/processarInscricoesOnline.php
@@ -696,6 +696,11 @@ $pageUI->renderJS(); // Render the widgets' JS code
 <script src="js/rowlink.js"></script>
 <script src="js/btn-group-hover.js"></script>
 <script type="text/javascript" src="js/DataTables/datatables.min.js"></script>
+<?php
+$dtLangUrl = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL)
+    ? 'js/DataTables/Portuguese-BR.json'
+    : 'js/DataTables/Portuguese.json';
+?>
 
 <script>
     $(function () {
@@ -713,7 +718,7 @@ $pageUI->renderJS(); // Render the widgets' JS code
             paging: false,
             info: false,
             language: {
-                url: 'js/DataTables/Portuguese.json'
+                url: '<?= $dtLangUrl ?>'
             }
         });
     });
@@ -723,7 +728,7 @@ $pageUI->renderJS(); // Render the widgets' JS code
             paging: false,
             info: false,
             language: {
-                url: 'js/DataTables/Portuguese.json'
+                url: '<?= $dtLangUrl ?>'
             }
         });
     } );
@@ -733,7 +738,7 @@ $pageUI->renderJS(); // Render the widgets' JS code
             paging: false,
             info: false,
             language: {
-                url: 'js/DataTables/Portuguese.json'
+                url: '<?= $dtLangUrl ?>'
             }
         });
     });
@@ -743,7 +748,7 @@ $pageUI->renderJS(); // Render the widgets' JS code
             paging: false,
             info: false,
             language: {
-                url: 'js/DataTables/Portuguese.json'
+                url: '<?= $dtLangUrl ?>'
             }
         });
     } );

--- a/renovacaoMatriculas.php
+++ b/renovacaoMatriculas.php
@@ -979,6 +979,11 @@ $pageUI->renderJS(); // Render the widgets' JS code
 <script src="js/bootstrap-switch.js"></script>
 <script type="text/javascript" src="js/DataTables/datatables.min.js"></script>
 <script src="js/btn-group-hover.js"></script>
+<?php
+$dtLangUrl = (\catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_LOCALIZATION_CODE) == \core\domain\Locale::BRASIL)
+    ? 'js/DataTables/Portuguese-BR.json'
+    : 'js/DataTables/Portuguese.json';
+?>
 
 <script>
 	
@@ -1014,7 +1019,7 @@ $(document).ready( function () {
         paging: false,
         info: false,
         language: {
-            url: 'js/DataTables/Portuguese.json'
+            url: '<?= $dtLangUrl ?>'
         }
     });
 } );
@@ -1024,7 +1029,7 @@ $(document).ready( function () {
         paging: false,
         info: false,
         language: {
-            url: 'js/DataTables/Portuguese.json'
+            url: '<?= $dtLangUrl ?>'
         }
     });
 });
@@ -1034,7 +1039,7 @@ $(document).ready( function () {
         paging: false,
         info: false,
         language: {
-            url: 'js/DataTables/Portuguese.json'
+            url: '<?= $dtLangUrl ?>'
         }
     });
 } );


### PR DESCRIPTION
## Summary
- add Brazilian Portuguese localization for DataTables
- pick DataTables translation according to localization setting

## Testing
- `php -l renovacaoMatriculas.php`
- `php -l processarInscricoesOnline.php`
- `php -l gui/widgets/SacramentList/SacramentListWidget.php`
- `php -l gui/widgets/CatechumensReport/CatechumensReportWidget.php`
- `php -l gui/widgets/CatechumensList/CatechumensListWidget.php`


------
https://chatgpt.com/codex/tasks/task_e_68800fbe303083289ef95b7e8901fea0