### PR TITLE
Refactor validation messages to use translations

### DIFF
--- a/inscricao.php
+++ b/inscricao.php
@@ -717,11 +717,11 @@ function validar()
         }
         
         
-	if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
-	{
-		alert("O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.");
-		return false;
-	}
+        if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
+        {
+                alert(<?= json_encode(Translation::t('invalid_postal_code')) ?>);
+                return false;
+        }
                 
         
         
@@ -732,13 +732,13 @@ function validar()
         }
         else if(telefone!="" && telefone!=undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-        	alert("O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.");
-		return false; 
+                alert(<?= json_encode(Translation::t('invalid_phone')) ?>);
+                return false;
         }
         else if(telemovel!="" && telemovel!=undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-        	alert("O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.");
-		return false; 
+                alert(<?= json_encode(Translation::t('invalid_phone')) ?>);
+                return false;
         }
         
         

--- a/locale/pt_BR.php
+++ b/locale/pt_BR.php
@@ -9,5 +9,9 @@ $lang = [
     'welcome_enrollment_platform' => 'Bem-vindo à plataforma de inscrições da catequese da %s!',
     'login_button' => 'Iniciar sessão'
     ,'welcome_update_assistant' => 'Bem-vindo ao assistente de atualização do CatecheSis!'
+    ,'invalid_postal_code' => "O CEP informado é inválido. Use o formato 'xxxxx-xxx Localidade'."
+    ,'invalid_phone' => "O número de telefone informado é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 dígitos."
+    ,'invalid_email' => 'O e-mail informado é inválido.'
+    ,'invalid_security_code' => 'O código de segurança informado não confere com a imagem.'
 ];
 return $lang;

--- a/locale/pt_PT.php
+++ b/locale/pt_PT.php
@@ -9,5 +9,9 @@ $lang = [
     'welcome_enrollment_platform' => 'Bem-vindo à plataforma de inscrições da catequese da %s!',
     'login_button' => 'Iniciar sessão'
     ,'welcome_update_assistant' => 'Bem-vindo ao assistente de atualização do CatecheSis!'
+    ,'invalid_postal_code' => "O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'."
+    ,'invalid_phone' => "O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos."
+    ,'invalid_email' => 'O e-mail que introduziu é inválido.'
+    ,'invalid_security_code' => 'O código de segurança que introduziu não corresponde ao mostrado na imagem.'
 ];
 return $lang;

--- a/mostrarAutorizacoes.php
+++ b/mostrarAutorizacoes.php
@@ -350,7 +350,7 @@ $menu->renderHTML();
                 }
                 if($telemovel_familiar=="" || !DataValidationUtils::validatePhoneNumber($telemovel_familiar, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
                 {
-                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_phone') . "</div>");
                     $inputs_invalidos = true;
                 }
 
@@ -767,7 +767,7 @@ function valida_dados_familiar()
     var telemovel = document.getElementById('telemovel').value;
     if(!telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
-        alert("O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.");
+        alert(<?= json_encode(Translation::t('invalid_phone')) ?>);
         return false;
     }
     return true;

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -788,11 +788,11 @@ function validar()
         }
         
         
-	if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
-	{
-		alert("O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.");
-		return false;
-	}
+        if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
+        {
+                alert(<?= json_encode(Translation::t('invalid_postal_code')) ?>);
+                return false;
+        }
                 
         
         
@@ -803,13 +803,13 @@ function validar()
         }
         else if(telefone!=="" && telefone!==undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-        	alert("O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.");
-		return false; 
+                alert(<?= json_encode(Translation::t('invalid_phone')) ?>);
+                return false;
         }
         else if(telemovel!=="" && telemovel!==undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-        	alert("O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.");
-		return false; 
+                alert(<?= json_encode(Translation::t('invalid_phone')) ?>);
+                return false;
         }
         
         

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -280,25 +280,25 @@ $menu->renderHTML();
 	  	}
 	  	
 	  		  	
-	  	if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.</div>");
-	  		var_dump($codigo_postal);
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_postal_code') . "</div>");
+                        var_dump($codigo_postal);
+                        $inputs_invalidos = true;
+                }
 	  	
 	  	
-	  	if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_phone') . "</div>");
+                        $inputs_invalidos = true;
+                }
 	  	
-	  	if($telemovel!="" && !DataValidationUtils::validatePhoneNumber($telemovel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if($telemovel!="" && !DataValidationUtils::validatePhoneNumber($telemovel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_phone') . "</div>");
+                        $inputs_invalidos = true;
+                }
 	  	
 	  	
 	  	if($baptizado && !DataValidationUtils::validateDate($data_baptismo))
@@ -347,7 +347,7 @@ $menu->renderHTML();
 	  	
 	  	if($email && $email!="" && !DataValidationUtils::validateEmail($email))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O e-mail que introduziu é inválido.</div>");
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_email') . "</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	

--- a/publico/consultarPedido.php
+++ b/publico/consultarPedido.php
@@ -114,7 +114,7 @@ $navbar->renderHTML();
         //Captcha validator
         if (!isset($captchaCode) || !Securimage::checkByCaptchaId($captchaId, $captchaCode, $captcha_options))
         {
-            echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código de segurança que introduziu não corresponde ao mostrado na imagem.</div>");
+            echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_security_code') . "</div>");
             echo("<p>Por favor <a href='javascript:history.go(-1)'>volte a tentar</a></p>");
             $inputs_invalidos = true;
         }

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -317,24 +317,24 @@ $navbar->renderHTML();
 	  	}
 	  	
 	  		  	
-	  	if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.</div>");
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_postal_code') . "</div>");
+                        $inputs_invalidos = true;
+                }
 	  	
 	  	
-	  	if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_phone') . "</div>");
+                        $inputs_invalidos = true;
+                }
 	  	
-	  	if($telemovel!="" && !DataValidationUtils::validatePhoneNumber($telemovel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if($telemovel!="" && !DataValidationUtils::validatePhoneNumber($telemovel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_phone') . "</div>");
+                        $inputs_invalidos = true;
+                }
 	  	
 	  	
 	  	if($baptizado==1 && !DataValidationUtils::validateDate($data_baptismo))
@@ -395,11 +395,11 @@ $navbar->renderHTML();
 	  		$inputs_invalidos = true;
 	  	}
 	  	
-	  	if($email && $email!="" && !DataValidationUtils::validateEmail($email))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O e-mail que introduziu é inválido.</div>");
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if($email && $email!="" && !DataValidationUtils::validateEmail($email))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_email') . "</div>");
+                        $inputs_invalidos = true;
+                }
 
 	  	if(isset($ultimo_catecismo) && ($ultimo_catecismo=="" || $ultimo_catecismo < 1 || $ultimo_catecismo > 10) )
         {
@@ -422,7 +422,7 @@ $navbar->renderHTML();
         //Captcha validator
         if (!isset($captchaCode) || !Securimage::checkByCaptchaId($captchaId, $captchaCode, $captcha_options))
         {
-            echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código de segurança que introduziu não corresponde ao mostrado na imagem.</div>");
+            echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_security_code') . "</div>");
             $inputs_invalidos = true;
         }
 

--- a/publico/doRenovarMatricula.php
+++ b/publico/doRenovarMatricula.php
@@ -143,13 +143,13 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
 
     if(!isset($enc_edu_tel) || $enc_edu_tel=="" || !DataValidationUtils::validatePhoneNumber($enc_edu_tel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
     {
-        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
+        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_phone') . "</div>");
         $inputs_invalidos = true;
     }
 
     if(isset($enc_edu_email) && $enc_edu_email!="" && !DataValidationUtils::validateEmail($enc_edu_email))
     {
-        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O e-mail que introduziu é inválido.</div>");
+        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_email') . "</div>");
         $inputs_invalidos = true;
     }
     else if(!isset($enc_edu_email) || $enc_edu_email=="")
@@ -158,7 +158,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
     //Captcha validator
     if (!isset($captchaCode) || !Securimage::checkByCaptchaId($captchaId, $captchaCode, $captcha_options))
     {
-        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código de segurança que introduziu não corresponde ao mostrado na imagem.</div>");
+        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . Translation::t('invalid_security_code') . "</div>");
         echo("<p>Por favor <a href='javascript:history.go(-1)'>volte a tentar</a></p>");
         $inputs_invalidos = true;
     }

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -779,11 +779,11 @@ function validar()
         }
         
         
-	if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
-	{
-		alert("O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.");
-		return false;
-	}
+        if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
+        {
+                alert(<?= json_encode(Translation::t('invalid_postal_code')) ?>);
+                return false;
+        }
                 
         
         
@@ -794,13 +794,13 @@ function validar()
         }
         else if(telefone!=="" && telefone!==undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-        	alert("O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.");
-		return false; 
+                alert(<?= json_encode(Translation::t('invalid_phone')) ?>);
+                return false;
         }
         else if(telemovel!=="" && telemovel!==undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-        	alert("O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.");
-		return false; 
+                alert(<?= json_encode(Translation::t('invalid_phone')) ?>);
+                return false;
         }
         
         

--- a/publico/renovarMatricula.php
+++ b/publico/renovarMatricula.php
@@ -227,12 +227,12 @@ $footer->renderHTML();
 
         if(telefone!=="" && telefone!==undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-            alert("O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.");
+            alert(<?= json_encode(Translation::t('invalid_phone')) ?>);
             return false;
         }
         if(email!=="" && email!==undefined && !email_valido(email))
         {
-            alert("O endereço de e-mail que introduziu é inválido.");
+            alert(<?= json_encode(Translation::t('invalid_email')) ?>);
             return false;
         }
 


### PR DESCRIPTION
## Summary
- use `Translation::t()` calls for common validation errors
- add default Portuguese text for new translation keys
- add Brazilian Portuguese translations

## Testing
- `php -l processarInscricao.php`
- `php -l publico/doInscrever.php`
- `php -l publico/doRenovarMatricula.php`
- `php -l publico/consultarPedido.php`
- `php -l mostrarAutorizacoes.php`
- `php -l inscricao.php`
- `php -l mostrarPedidoInscricao.php`
- `php -l publico/inscrever.php`
- `php -l publico/renovarMatricula.php`
- `php -l locale/pt_BR.php`
- `php -l locale/pt_PT.php`


------
https://chatgpt.com/codex/tasks/task_e_68800fbecfc88328ac01922bc6d86f87