### PR TITLE
Add CSRF validation for payments

### DIFF
--- a/pagamentos.php
+++ b/pagamentos.php
@@ -26,6 +26,12 @@ $db = new PdoDatabaseManager();
 $message = null;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['cid'])) {
+    if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+    {
+        echo("<div class='alert alert-danger'><strong>ERRO!</strong> Pedido inválido.</div>");
+        die();
+    }
+
     $cid = intval(Utils::sanitizeInput($_POST['cid']));
     $amount = 100.0; // Fixed amount
     $status = 'confirmado';
@@ -87,6 +93,7 @@ $menu->renderHTML();
   <hr>
   <h3>Registar novo pagamento</h3>
   <form method="post" action="pagamentos.php" class="form-inline">
+    <input type="hidden" name="csrf_token" value="<?= \catechesis\Utils::getCSRFToken() ?>">
     <div class="form-group">
       <label for="cid">Catequizando:</label>
       <input type="number" class="form-control" id="cid" name="cid" required>


### PR DESCRIPTION
## Summary
- inject CSRF token hidden field into payments form
- verify the token server-side and show an error when invalid

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6880f5b361b883289cc97f8ec77add3f