### PR TITLE
Improve payment verification

### DIFF
--- a/core/Configurator.php
+++ b/core/Configurator.php
@@ -125,6 +125,7 @@ class Configurator
     const KEY_ENROLLMENT_PAYMENT_PROOF = "ENROLLMENT_PAYMENT_PROOF";                                                    //E-mail address or URL (ex: a cloud folder) to which payers should send the proof of payment
     const KEY_PAYMENT_PROVIDER_URL = "PAYMENT_PROVIDER_URL";            //Endpoint used to verify enrollment payments
     const KEY_PAYMENT_PROVIDER_TOKEN = "PAYMENT_PROVIDER_TOKEN";        //Authentication token for the payment provider API
+    const KEY_PAYMENT_PROVIDER_TIMEOUT = "PAYMENT_PROVIDER_TIMEOUT";    //Timeout in seconds when contacting the provider
 
 
     const KEY_CATECHESIS_NEXTCLOUD_BASE_URL = "CATECHESIS_NEXTCLOUD_BASE_URL";                                          //Path to Nextcloud front page
@@ -177,6 +178,7 @@ class Configurator
                 self::KEY_ENROLLMENT_PAYMENT_PROOF => new ConfigurationObject(self::KEY_ENROLLMENT_PAYMENT_PROOF, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_PAYMENT_PROVIDER_URL => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_URL, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_PAYMENT_PROVIDER_TOKEN => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_TOKEN, ConfigurationObject::TYPE_STRING, null),
+                self::KEY_PAYMENT_PROVIDER_TIMEOUT => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_TIMEOUT, ConfigurationObject::TYPE_INT, 10),
                 self::KEY_CATECHESIS_NEXTCLOUD_BASE_URL => new ConfigurationObject(self::KEY_CATECHESIS_NEXTCLOUD_BASE_URL, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL => new ConfigurationObject(self::KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL, ConfigurationObject::TYPE_STRING, null),
 

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -249,7 +249,8 @@ $menu->renderHTML();
                 }
                 catch (Exception $e)
                 {
-                    // Ignore verification errors and proceed with submitted value
+                    error_log('Payment verification failed: ' . $e->getMessage());
+                    echo("<div class=\"alert alert-warning\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Atenção!</strong> Não foi possível verificar automaticamente o pagamento. Por favor confirme manualmente.</div>");
                 }
  		
 		


### PR DESCRIPTION
## Summary
- use cURL instead of `file_get_contents` when checking payment provider
- support configurable timeout via `KEY_PAYMENT_PROVIDER_TIMEOUT`
- log and display warnings when payment verification fails

## Testing
- `php -l core/PaymentVerificationService.php`
- `php -l processarInscricao.php`
- `php -l core/Configurator.php`

------
https://chatgpt.com/codex/tasks/task_e_6880f5b4a1808328b533ca57dee8bb1b