### PR TITLE
Add PHPUnit setup with basic unit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="Catechesis Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -1,0 +1,16 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use catechesis\Utils;
+
+require_once __DIR__ . '/../core/Utils.php';
+
+class CsrfTest extends TestCase
+{
+    public function testInvalidTokenIsRejected(): void
+    {
+        $_SESSION = [];
+        $token = Utils::getCSRFToken();
+        $this->assertFalse(Utils::verifyCSRFToken('invalid')); // mismatch
+    }
+}
+?>

--- a/tests/PaymentVerificationServiceTest.php
+++ b/tests/PaymentVerificationServiceTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace catechesis {
+    function file_get_contents($filename, $use_include_path = false, $context = null) {
+        return \PaymentVerificationServiceTest::$mockResponse;
+    }
+}
+
+use catechesis\PaymentVerificationService;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../core/PaymentVerificationService.php';
+
+class PaymentVerificationServiceTest extends TestCase
+{
+    public static $mockResponse;
+
+    public function testVerifyPaymentSuccess(): void
+    {
+        self::$mockResponse = json_encode(['paid' => true, 'amount' => 20]);
+        $service = new PaymentVerificationService('http://example', 'token');
+        $this->assertTrue($service->verifyPayment(1, '123', 10));
+    }
+
+    public function testVerifyPaymentInsufficientAmount(): void
+    {
+        self::$mockResponse = json_encode(['paid' => true, 'amount' => 5]);
+        $service = new PaymentVerificationService('http://example', 'token');
+        $this->assertFalse($service->verifyPayment(1, '123', 10));
+    }
+
+    public function testVerifyPaymentFailure(): void
+    {
+        self::$mockResponse = false;
+        $service = new PaymentVerificationService('http://example', 'token');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Failed to connect to payment provider.');
+        $service->verifyPayment(1, '123', 10);
+    }
+
+    public function testVerifyPaymentInvalidResponse(): void
+    {
+        self::$mockResponse = 'invalid';
+        $service = new PaymentVerificationService('http://example', 'token');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid response from payment provider.');
+        $service->verifyPayment(1, '123', 10);
+    }
+}
+?>

--- a/tests/PdoDatabaseManagerTest.php
+++ b/tests/PdoDatabaseManagerTest.php
@@ -1,0 +1,52 @@
+<?php
+use catechesis\PdoDatabaseManager;
+use catechesis\DatabaseAccessMode;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../core/PdoDatabaseManager.php';
+require_once __DIR__ . '/../core/DatabaseManager.php';
+// DatabaseAccessMode class is defined in DatabaseManager.php
+
+class PdoDatabaseManagerTest extends TestCase
+{
+    private PDO $pdo;
+    private PdoDatabaseManager $manager;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('CREATE TABLE pagamentos (
+            pid INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT,
+            cid INTEGER,
+            valor REAL,
+            estado TEXT,
+            data_pagamento TEXT
+        );');
+
+        $this->manager = new PdoDatabaseManager();
+        $ref = new ReflectionClass(PdoDatabaseManager::class);
+        $connProp = $ref->getProperty('_connection');
+        $modeProp = $ref->getProperty('_connection_access_mode');
+        $connProp->setAccessible(true);
+        $modeProp->setAccessible(true);
+        $connProp->setValue($this->manager, $this->pdo);
+        $modeProp->setValue($this->manager, DatabaseAccessMode::DEFAULT_EDIT);
+    }
+
+    public function testInsertPayment(): void
+    {
+        $result = $this->manager->insertPayment('john', 1, 10.5, 'pendente');
+        $this->assertTrue($result);
+
+        $stmt = $this->pdo->query('SELECT username, cid, valor, estado FROM pagamentos');
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertEquals('john', $row['username']);
+        $this->assertEquals(1, $row['cid']);
+        $this->assertEquals(10.5, $row['valor']);
+        $this->assertEquals('pendente', $row['estado']);
+    }
+}
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+// Test bootstrap
+session_start();
+?>


### PR DESCRIPTION
## Summary
- add `phpunit.xml` to configure the test suite
- create a bootstrap file for tests
- implement unit tests for `PdoDatabaseManager::insertPayment`
- implement unit tests for `PaymentVerificationService::verifyPayment`
- test CSRF token validation

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6880f5b612d08328aef2e8e4acb5c1d3