### PR TITLE
Add Pix payment support

### DIFF
--- a/core/Configurator.php
+++ b/core/Configurator.php
@@ -127,6 +127,13 @@ class Configurator
     const KEY_PAYMENT_PROVIDER_TOKEN = "PAYMENT_PROVIDER_TOKEN";        //Authentication token for the payment provider API
     const KEY_PAYMENT_PROVIDER_TIMEOUT = "PAYMENT_PROVIDER_TIMEOUT";    //Timeout in seconds when contacting the provider
 
+    // Pix payment details
+    const KEY_PIX_RECEIVER = "PIX_RECEIVER";            // Name of the receiver displayed on the Pix slip
+    const KEY_PIX_CITY = "PIX_CITY";                    // City used in Pix payload
+    const KEY_PIX_KEY = "PIX_KEY";                      // Pix key identifier
+    const KEY_PIX_API_URL = "PIX_API_URL";              // Endpoint for Pix payment generation
+    const KEY_PIX_API_TOKEN = "PIX_API_TOKEN";          // Authentication token for the Pix API
+
 
     const KEY_CATECHESIS_NEXTCLOUD_BASE_URL = "CATECHESIS_NEXTCLOUD_BASE_URL";                                          //Path to Nextcloud front page
     const KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL = "CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL";                //Path to public shared folder in Nextcloud to store virtual catechesis resources
@@ -179,6 +186,11 @@ class Configurator
                 self::KEY_PAYMENT_PROVIDER_URL => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_URL, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_PAYMENT_PROVIDER_TOKEN => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_TOKEN, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_PAYMENT_PROVIDER_TIMEOUT => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_TIMEOUT, ConfigurationObject::TYPE_INT, 10),
+                self::KEY_PIX_RECEIVER => new ConfigurationObject(self::KEY_PIX_RECEIVER, ConfigurationObject::TYPE_STRING, null),
+                self::KEY_PIX_CITY => new ConfigurationObject(self::KEY_PIX_CITY, ConfigurationObject::TYPE_STRING, null),
+                self::KEY_PIX_KEY => new ConfigurationObject(self::KEY_PIX_KEY, ConfigurationObject::TYPE_STRING, null),
+                self::KEY_PIX_API_URL => new ConfigurationObject(self::KEY_PIX_API_URL, ConfigurationObject::TYPE_STRING, null),
+                self::KEY_PIX_API_TOKEN => new ConfigurationObject(self::KEY_PIX_API_TOKEN, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_CATECHESIS_NEXTCLOUD_BASE_URL => new ConfigurationObject(self::KEY_CATECHESIS_NEXTCLOUD_BASE_URL, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL => new ConfigurationObject(self::KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL, ConfigurationObject::TYPE_STRING, null),
 

--- a/gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php
+++ b/gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php
@@ -57,6 +57,11 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
         $paymentAmount = 0.0;
         $acceptDonations = true;
         $paymentProof = null;
+        $pixReceiver = null;
+        $pixCity = null;
+        $pixKey = null;
+        $pixApiUrl = null;
+        $pixApiToken = null;
 
         //Load configuration settings
         try
@@ -69,6 +74,11 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
             $paymentAmount =  Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT);
             $acceptDonations =  Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS);
             $paymentProof =  Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_PROOF);
+            $pixReceiver = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_RECEIVER);
+            $pixCity = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_CITY);
+            $pixKey = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_KEY);
+            $pixApiUrl = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_URL);
+            $pixApiToken = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_TOKEN);
         }
         catch(\Exception $e)
         {
@@ -165,6 +175,37 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
                         <input type="text" class="form-control" id="<?=$this->getID()?>_proof" name="proof" placeholder="" style="cursor: auto;" value="<?= $paymentProof ?>" readonly>
                         <input type="hidden" class="form-control" id="<?=$this->getID()?>_proof_backup" value="<?= $paymentProof ?>" readonly>
                     </div>
+
+                    <div class="row clearfix" style="margin-bottom: 10px;"></div>
+                    <div class="col-md-4">
+                        <label for="<?=$this->getID()?>_pix_receiver">Destinatário PIX:</label>
+                        <input type="text" class="form-control" id="<?=$this->getID()?>_pix_receiver" name="pix_receiver" placeholder="" style="cursor: auto;" value="<?= $pixReceiver ?>" readonly>
+                        <input type="hidden" class="form-control" id="<?=$this->getID()?>_pix_receiver_backup" value="<?= $pixReceiver ?>" readonly>
+                    </div>
+                    <div class="row clearfix" style="margin-bottom: 10px;"></div>
+                    <div class="col-md-4">
+                        <label for="<?=$this->getID()?>_pix_city">Cidade PIX:</label>
+                        <input type="text" class="form-control" id="<?=$this->getID()?>_pix_city" name="pix_city" placeholder="" style="cursor: auto;" value="<?= $pixCity ?>" readonly>
+                        <input type="hidden" class="form-control" id="<?=$this->getID()?>_pix_city_backup" value="<?= $pixCity ?>" readonly>
+                    </div>
+                    <div class="row clearfix" style="margin-bottom: 10px;"></div>
+                    <div class="col-md-4">
+                        <label for="<?=$this->getID()?>_pix_key">Chave PIX:</label>
+                        <input type="text" class="form-control" id="<?=$this->getID()?>_pix_key" name="pix_key" placeholder="" style="cursor: auto;" value="<?= $pixKey ?>" readonly>
+                        <input type="hidden" class="form-control" id="<?=$this->getID()?>_pix_key_backup" value="<?= $pixKey ?>" readonly>
+                    </div>
+
+                    <div class="row clearfix" style="margin-bottom: 10px;"></div>
+                    <div class="col-md-6">
+                        <label for="<?=$this->getID()?>_pix_api_url">PIX API URL:</label>
+                        <input type="text" class="form-control" id="<?=$this->getID()?>_pix_api_url" name="pix_api_url" placeholder="" style="cursor: auto;" value="<?= $pixApiUrl ?>" readonly>
+                        <input type="hidden" class="form-control" id="<?=$this->getID()?>_pix_api_url_backup" value="<?= $pixApiUrl ?>" readonly>
+                    </div>
+                    <div class="col-md-6">
+                        <label for="<?=$this->getID()?>_pix_api_token">PIX API Token:</label>
+                        <input type="text" class="form-control" id="<?=$this->getID()?>_pix_api_token" name="pix_api_token" placeholder="" style="cursor: auto;" value="<?= $pixApiToken ?>" readonly>
+                        <input type="hidden" class="form-control" id="<?=$this->getID()?>_pix_api_token_backup" value="<?= $pixApiToken ?>" readonly>
+                    </div>
                 </div>
             </div>
 
@@ -206,6 +247,11 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
         document.getElementById("<?=$this->getID()?>_allow_donations").disabled = false;
         document.getElementById("<?=$this->getID()?>_div_allow_donations").classList.remove("disabled");
         document.getElementById("<?=$this->getID()?>_proof").readOnly = false;
+        document.getElementById("<?=$this->getID()?>_pix_receiver").readOnly = false;
+        document.getElementById("<?=$this->getID()?>_pix_city").readOnly = false;
+        document.getElementById("<?=$this->getID()?>_pix_key").readOnly = false;
+        document.getElementById("<?=$this->getID()?>_pix_api_url").readOnly = false;
+        document.getElementById("<?=$this->getID()?>_pix_api_token").readOnly = false;
         document.getElementById("<?=$this->getID()?>_form_action").value = "<?= self::$ACTION_CHANGE_DETAILS ?>"; //Change form mode to details
         <?php
     }
@@ -227,12 +273,22 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
         document.getElementById("<?=$this->getID()?>_allow_donations").disabled = true;
         document.getElementById("<?=$this->getID()?>_div_allow_donations").classList.add("disabled");
         document.getElementById("<?=$this->getID()?>_proof").readOnly = true;
+        document.getElementById("<?=$this->getID()?>_pix_receiver").readOnly = true;
+        document.getElementById("<?=$this->getID()?>_pix_city").readOnly = true;
+        document.getElementById("<?=$this->getID()?>_pix_key").readOnly = true;
+        document.getElementById("<?=$this->getID()?>_pix_api_url").readOnly = true;
+        document.getElementById("<?=$this->getID()?>_pix_api_token").readOnly = true;
 
         <?=$this->getID()?>_quill.root.innerHTML = document.getElementById("<?=$this->getID()?>_info_text_backup").value;
         document.getElementById("<?=$this->getID()?>_entity").value = document.getElementById("<?=$this->getID()?>_entity_backup").value;
         document.getElementById("<?=$this->getID()?>_reference").value = document.getElementById("<?=$this->getID()?>_reference_backup").value;
         document.getElementById("<?=$this->getID()?>_amount").value = document.getElementById("<?=$this->getID()?>_amount_backup").value;
         document.getElementById("<?=$this->getID()?>_proof").value = document.getElementById("<?=$this->getID()?>_proof_backup").value;
+        document.getElementById("<?=$this->getID()?>_pix_receiver").value = document.getElementById("<?=$this->getID()?>_pix_receiver_backup").value;
+        document.getElementById("<?=$this->getID()?>_pix_city").value = document.getElementById("<?=$this->getID()?>_pix_city_backup").value;
+        document.getElementById("<?=$this->getID()?>_pix_key").value = document.getElementById("<?=$this->getID()?>_pix_key_backup").value;
+        document.getElementById("<?=$this->getID()?>_pix_api_url").value = document.getElementById("<?=$this->getID()?>_pix_api_url_backup").value;
+        document.getElementById("<?=$this->getID()?>_pix_api_token").value = document.getElementById("<?=$this->getID()?>_pix_api_token_backup").value;
 
         if(document.getElementById("<?=$this->getID()?>_enable_payment_backup").value == "on")
             document.getElementById("<?=$this->getID()?>_enable_payment").checked = true;
@@ -370,6 +426,11 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
             $paymentAmount =  Utils::sanitizeInput($_POST['amount']);
             $acceptDonations = Utils::sanitizeInput($_POST['allow_donations']); $acceptDonations = ($acceptDonations=="on");
             $paymentProof = Utils::sanitizeInput($_POST['proof']);
+            $pixReceiver = Utils::sanitizeInput($_POST['pix_receiver']);
+            $pixCity = Utils::sanitizeInput($_POST['pix_city']);
+            $pixKey = Utils::sanitizeInput($_POST['pix_key']);
+            $pixApiUrl = Utils::sanitizeInput($_POST['pix_api_url']);
+            $pixApiToken = Utils::sanitizeInput($_POST['pix_api_token']);
 
             $inputs_valid = true;
             if($showPaymentData)
@@ -408,6 +469,11 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
                     Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT, $paymentAmount);
                     Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_ACCEPT_BIGGER_DONATIONS, $acceptDonations);
                     Configurator::setConfigurationValue(Configurator::KEY_ENROLLMENT_PAYMENT_PROOF, $paymentProof);
+                    Configurator::setConfigurationValue(Configurator::KEY_PIX_RECEIVER, $pixReceiver);
+                    Configurator::setConfigurationValue(Configurator::KEY_PIX_CITY, $pixCity);
+                    Configurator::setConfigurationValue(Configurator::KEY_PIX_KEY, $pixKey);
+                    Configurator::setConfigurationValue(Configurator::KEY_PIX_API_URL, $pixApiUrl);
+                    Configurator::setConfigurationValue(Configurator::KEY_PIX_API_TOKEN, $pixApiToken);
 
                     writeLogEntry("Modificou configurações das inscrições/renovações de matrícula online.");
                     echo("<div class=\"alert alert-success\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Sucesso!</strong> Modificou as configurações das inscrições/renovações de matrícula online.</div>");


### PR DESCRIPTION
## Summary
- add configuration constants for Pix payment
- allow editing Pix options in the online enrollment panel

## Testing
- `php -l core/Configurator.php`
- `php -l gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php`
- ❌ `composer global require phpunit/phpunit` *(failed: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68810abaf6c88328a29e8326314f7a93