### PR TITLE
Add Pix payment verification service

### DIFF
--- a/core/Configurator.php
+++ b/core/Configurator.php
@@ -126,6 +126,10 @@ class Configurator
     const KEY_PAYMENT_PROVIDER_URL = "PAYMENT_PROVIDER_URL";            //Endpoint used to verify enrollment payments
     const KEY_PAYMENT_PROVIDER_TOKEN = "PAYMENT_PROVIDER_TOKEN";        //Authentication token for the payment provider API
     const KEY_PAYMENT_PROVIDER_TIMEOUT = "PAYMENT_PROVIDER_TIMEOUT";    //Timeout in seconds when contacting the provider
+    const KEY_PIX_PROVIDER_URL = "PIX_PROVIDER_URL";            //Endpoint for Pix payment verification
+    const KEY_PIX_PROVIDER_TOKEN = "PIX_PROVIDER_TOKEN";        //Authentication token for Pix API
+    const KEY_PIX_PROVIDER_TIMEOUT = "PIX_PROVIDER_TIMEOUT";    //Timeout in seconds when contacting the Pix API
+    const KEY_PIX_KEY = "PIX_KEY";                              //Pix key associated with the parish
 
 
     const KEY_CATECHESIS_NEXTCLOUD_BASE_URL = "CATECHESIS_NEXTCLOUD_BASE_URL";                                          //Path to Nextcloud front page
@@ -179,6 +183,10 @@ class Configurator
                 self::KEY_PAYMENT_PROVIDER_URL => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_URL, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_PAYMENT_PROVIDER_TOKEN => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_TOKEN, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_PAYMENT_PROVIDER_TIMEOUT => new ConfigurationObject(self::KEY_PAYMENT_PROVIDER_TIMEOUT, ConfigurationObject::TYPE_INT, 10),
+                self::KEY_PIX_PROVIDER_URL => new ConfigurationObject(self::KEY_PIX_PROVIDER_URL, ConfigurationObject::TYPE_STRING, null),
+                self::KEY_PIX_PROVIDER_TOKEN => new ConfigurationObject(self::KEY_PIX_PROVIDER_TOKEN, ConfigurationObject::TYPE_STRING, null),
+                self::KEY_PIX_PROVIDER_TIMEOUT => new ConfigurationObject(self::KEY_PIX_PROVIDER_TIMEOUT, ConfigurationObject::TYPE_INT, 10),
+                self::KEY_PIX_KEY => new ConfigurationObject(self::KEY_PIX_KEY, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_CATECHESIS_NEXTCLOUD_BASE_URL => new ConfigurationObject(self::KEY_CATECHESIS_NEXTCLOUD_BASE_URL, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL => new ConfigurationObject(self::KEY_CATECHESIS_NEXTCLOUD_VIRTUAL_RESOURCES_URL, ConfigurationObject::TYPE_STRING, null),
 

--- a/core/PixPaymentVerificationService.php
+++ b/core/PixPaymentVerificationService.php
@@ -1,0 +1,92 @@
+<?php
+namespace catechesis;
+
+use Exception;
+use catechesis\Configurator;
+
+/**
+ * Service to verify Pix payments for an enrolment using an external API.
+ * The API is expected to return a JSON payload with fields 'paid' and 'amount'.
+ */
+class PixPaymentVerificationService
+{
+    private string $endpoint;
+    private string $token;
+    private int $timeout;
+
+    public function __construct(?string $endpoint = null, ?string $token = null, ?int $timeout = null)
+    {
+        $this->endpoint = $endpoint ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_PROVIDER_URL);
+        $this->token     = $token ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_PROVIDER_TOKEN);
+        if ($timeout === null)
+            $timeout = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_PROVIDER_TIMEOUT);
+        $this->timeout   = $timeout ?? 10;
+    }
+
+    /**
+     * Queries the Pix provider and checks if payment was received.
+     * Either $enrollmentId or $pixKey must be provided.
+     *
+     * @param int|null    $enrollmentId  Enrollment identifier
+     * @param string|null $pixKey        Pix key
+     * @param float       $amount        Expected amount
+     *
+     * @return bool True if the provider reports payment with at least the given amount.
+     * @throws Exception When the provider is unreachable or returns an invalid response.
+     */
+    public function verifyPayment(?int $enrollmentId, ?string $pixKey, float $amount): bool
+    {
+        if (!$this->endpoint || !$this->token) {
+            throw new Exception('Pix provider not configured.');
+        }
+        if ($enrollmentId === null && $pixKey === null) {
+            throw new Exception('Enrollment ID or Pix key must be provided.');
+        }
+
+        $params = [];
+        if ($enrollmentId !== null) {
+            $params['enrollment_id'] = $enrollmentId;
+        }
+        if ($pixKey !== null) {
+            $params['pix_key'] = $pixKey;
+        }
+
+        $query = http_build_query($params);
+        $url   = rtrim($this->endpoint, '/') . '/?' . $query;
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ["Authorization: Bearer {$this->token}"]);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->timeout);
+
+        if (stripos($url, 'https://') === 0) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        }
+
+        $response = curl_exec($ch);
+        $status   = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($response === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            error_log('Pix provider connection error: ' . $error);
+            throw new Exception('Failed to connect to Pix provider.');
+        }
+        curl_close($ch);
+
+        if ($status < 200 || $status >= 300) {
+            error_log("Pix provider HTTP error ({$status}): {$response}");
+            throw new Exception('Pix provider returned an error.');
+        }
+
+        $data = json_decode($response, true);
+        if (!is_array($data) || !isset($data['paid']) || !isset($data['amount'])) {
+            error_log('Pix provider invalid response: ' . $response);
+            throw new Exception('Invalid response from Pix provider.');
+        }
+
+        return ($data['paid'] === true || $data['paid'] === 1 || $data['paid'] === '1')
+            && floatval($data['amount']) >= $amount;
+    }
+}

--- a/tests/PixPaymentVerificationServiceTest.php
+++ b/tests/PixPaymentVerificationServiceTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace catechesis {
+    function file_get_contents($filename, $use_include_path = false, $context = null) {
+        return \PixPaymentVerificationServiceTest::$mockResponse;
+    }
+}
+
+use catechesis\PixPaymentVerificationService;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../core/PixPaymentVerificationService.php';
+
+class PixPaymentVerificationServiceTest extends TestCase
+{
+    public static $mockResponse;
+
+    public function testVerifyPaymentSuccess(): void
+    {
+        self::$mockResponse = json_encode(['paid' => true, 'amount' => 20]);
+        $service = new PixPaymentVerificationService('http://example', 'token');
+        $this->assertTrue($service->verifyPayment(1, 'key', 10));
+    }
+
+    public function testVerifyPaymentInsufficientAmount(): void
+    {
+        self::$mockResponse = json_encode(['paid' => true, 'amount' => 5]);
+        $service = new PixPaymentVerificationService('http://example', 'token');
+        $this->assertFalse($service->verifyPayment(1, 'key', 10));
+    }
+
+    public function testVerifyPaymentFailure(): void
+    {
+        self::$mockResponse = false;
+        $service = new PixPaymentVerificationService('http://example', 'token');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Failed to connect to Pix provider.');
+        $service->verifyPayment(1, 'key', 10);
+    }
+
+    public function testVerifyPaymentInvalidResponse(): void
+    {
+        self::$mockResponse = 'invalid';
+        $service = new PixPaymentVerificationService('http://example', 'token');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid response from Pix provider.');
+        $service->verifyPayment(1, 'key', 10);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- support automatic Pix payment verification
- configure Pix API parameters
- mark enrolments paid when Pix API confirms payment
- record confirmed payments in `pagamentos`
- add tests for PixPaymentVerificationService

## Testing
- `php -l core/PixPaymentVerificationService.php`
- `php -l processarInscricao.php`
- `php -l renovacaoMatriculas.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68810abbcc18832885347513c2185427