### PR TITLE
Update Pix API config key names

### DIFF
--- a/core/PixPaymentVerificationService.php
+++ b/core/PixPaymentVerificationService.php
@@ -16,10 +16,10 @@ class PixPaymentVerificationService
 
     public function __construct(?string $endpoint = null, ?string $token = null, ?int $timeout = null)
     {
-        $this->endpoint = $endpoint ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_PROVIDER_URL);
-        $this->token     = $token ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_PROVIDER_TOKEN);
+        $this->endpoint = $endpoint ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_URL);
+        $this->token     = $token ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_TOKEN);
         if ($timeout === null)
-            $timeout = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_PROVIDER_TIMEOUT);
+            $timeout = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_TIMEOUT);
         $this->timeout   = $timeout ?? 10;
     }
 


### PR DESCRIPTION
## Summary
- use the new `KEY_PIX_API_*` constants when initializing PixPaymentVerificationService

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812a13f3648328b2150b8578da2515