### PR TITLE
Adapt ZIP code patterns per locale

### DIFF
--- a/inscricao.php
+++ b/inscricao.php
@@ -182,7 +182,7 @@ $menu->renderHTML();
     <div class="col-xs-4">
     <div id="codigo_postal_div">
       <label for="codigo_postal">Código postal:</label>
-      <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="xxxx-xxx Localidade" list="codigos_postais" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
+      <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx Localidade':'xxxx-xxx Localidade' ?>" list="codigos_postais" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
       <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
     </div>
     </div>
@@ -714,11 +714,11 @@ function validar()
         }
         
         
-	if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
-	{
-		alert("O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.");
-		return false;
-	}
+        if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
+        {
+                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx' ?> Localidade'.");
+                return false;
+        }
                 
         
         

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -309,7 +309,7 @@ $db = new PdoDatabaseManager();
                 <div class="col-lg-4">
                 <div id="codigo_postal_div">
                   <label for="codigo_postal">Código postal:</label>
-                  <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="xxxx-xxx Localidade" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php echo($submission['cod_postal']);?>" readonly required>
+                  <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx Localidade':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php echo($submission['cod_postal']);?>" readonly required>
                   <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
                 </div>
                 </div>
@@ -785,11 +785,11 @@ function validar()
         }
         
         
-	if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
-	{
-		alert("O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.");
-		return false;
-	}
+        if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
+        {
+                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx' ?> Localidade'.");
+                return false;
+        }
                 
         
         

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -305,12 +305,14 @@ $menu->renderHTML();
 	  	}
 	  	
 	  		  	
-	  	if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.</div>");
-	  		var_dump($codigo_postal);
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma '" .
+                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"xxxxx-xxx":"xxxx-xxx") .
+                             " Localidade'.</div>");
+                        var_dump($codigo_postal);
+                        $inputs_invalidos = true;
+                }
 	  	
 	  	
 	  	if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -319,11 +319,13 @@ $navbar->renderHTML();
 	  	}
 	  	
 	  		  	
-	  	if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
-	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.</div>");
-	  		$inputs_invalidos = true;	  	
-	  	}
+                if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
+                {
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma '" .
+                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"xxxxx-xxx":"xxxx-xxx") .
+                             " Localidade'.</div>");
+                        $inputs_invalidos = true;
+                }
 	  	
 	  	
 	  	if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -307,7 +307,7 @@ $pageUI->addWidget($footer);
                         <div class="col-lg-4">
                         <div id="codigo_postal_div">
                           <label for="codigo_postal">Código postal:</label>
-                          <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="xxxx-xxx Localidade" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
+                          <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx Localidade':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
                           <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
                         </div>
                         </div>
@@ -776,11 +776,11 @@ function validar()
         }
         
         
-	if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
-	{
-		alert("O código postal que introduziu é inválido. Deve ser da forma 'xxxx-yyy Localidade'.");
-		return false;
-	}
+        if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
+        {
+                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx' ?> Localidade'.");
+                return false;
+        }
                 
         
         


### PR DESCRIPTION
## Summary
- support BR/PT postal code placeholder in forms
- show correct postal code format in JavaScript alerts
- show correct postal code format in PHP validation errors

## Testing
- `php -l inscricao.php`
- `php -l publico/inscrever.php`
- `php -l mostrarPedidoInscricao.php`
- `php -l processarInscricao.php`
- `php -l publico/doInscrever.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68813069c5e0832895b5872b8fe4d54d