### PR TITLE
Set Brazilian defaults for localization

### DIFF
--- a/core/Configurator.php
+++ b/core/Configurator.php
@@ -165,7 +165,7 @@ class Configurator
                 self::KEY_PARISH_DIOCESE => new ConfigurationObject(self::KEY_PARISH_DIOCESE, ConfigurationObject::TYPE_STRING, null),
                 self::KEY_PARISH_CUSTOM_TABLE_FOOTER => new ConfigurationObject(self::KEY_PARISH_CUSTOM_TABLE_FOOTER, ConfigurationObject::TYPE_STRING, null),
 
-                self::KEY_LOCALIZATION_CODE => new ConfigurationObject(self::KEY_LOCALIZATION_CODE, ConfigurationObject::TYPE_STRING, "PT"),
+                self::KEY_LOCALIZATION_CODE => new ConfigurationObject(self::KEY_LOCALIZATION_CODE, ConfigurationObject::TYPE_STRING, "BR"),
 
                 self::KEY_GDPR_RESPONSIBLE_NAME => new ConfigurationObject(self::KEY_GDPR_RESPONSIBLE_NAME, ConfigurationObject::TYPE_STRING, "a Catequese Paroquial NOME DA PARÓQUIA"),
                 self::KEY_GDPR_RESPONSBILE_ADDRESS => new ConfigurationObject(self::KEY_GDPR_RESPONSBILE_ADDRESS, ConfigurationObject::TYPE_STRING, null),


### PR DESCRIPTION
## Summary
- update default locale from PT to BR in `Configurator`

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881306b766883288cfc2778c6c265db