### PR TITLE
Fix Brazilian CEP handling

### DIFF
--- a/core/DataValidationUtils.php
+++ b/core/DataValidationUtils.php
@@ -72,7 +72,8 @@ class DataValidationUtils
         if($locale == Locale::PORTUGAL)
             $pattern = '/^[0-9]{4}\-[0-9]{3}\s\S+/';
         else if($locale == Locale::BRASIL)
-            $pattern = '/^[0-9]{5}\-[0-9]{3}\s\S+/';
+            // Brazilian zip code with optional locality
+            $pattern = '/^[0-9]{5}\-[0-9]{3}(\s\S+)?/';
 
         return (preg_match($pattern, $postal));
     }

--- a/inscricao.php
+++ b/inscricao.php
@@ -182,7 +182,7 @@ $menu->renderHTML();
     <div class="col-xs-4">
     <div id="codigo_postal_div">
       <label for="codigo_postal">Código postal:</label>
-      <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx Localidade':'xxxx-xxx Localidade' ?>" list="codigos_postais" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
+      <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>" list="codigos_postais" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
       <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
     </div>
     </div>
@@ -716,7 +716,7 @@ function validar()
         
         if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx' ?> Localidade'.");
+                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>'.");
                 return false;
         }
                 

--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -23,7 +23,8 @@ function codigo_postal_valido(codigo, locale)
     if(locale==="PT")
         pattern = /^[0-9]{4}\-[0-9]{3}\s\S+/;
     else if(locale==="BR")
-        pattern = /^[0-9]{5}\-[0-9]{3}\s\S+/;
+        // Brazilian zip code with optional locality
+        pattern = /^[0-9]{5}\-[0-9]{3}(\s\S+)?/;
 
     return (pattern.test(codigo));
 }

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -309,7 +309,7 @@ $db = new PdoDatabaseManager();
                 <div class="col-lg-4">
                 <div id="codigo_postal_div">
                   <label for="codigo_postal">Código postal:</label>
-                  <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx Localidade':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php echo($submission['cod_postal']);?>" readonly required>
+                  <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php echo($submission['cod_postal']);?>" readonly required>
                   <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
                 </div>
                 </div>
@@ -787,7 +787,7 @@ function validar()
         
         if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx' ?> Localidade'.");
+                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>'.");
                 return false;
         }
                 

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -308,8 +308,8 @@ $menu->renderHTML();
                 if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
                 {
                         echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma '" .
-                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"xxxxx-xxx":"xxxx-xxx") .
-                             " Localidade'.</div>");
+                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"xxxxx-xxx":"xxxx-xxx Localidade") .
+                             "'.</div>");
                         var_dump($codigo_postal);
                         $inputs_invalidos = true;
                 }

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -322,8 +322,8 @@ $navbar->renderHTML();
                 if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
                 {
                         echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma '" .
-                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"xxxxx-xxx":"xxxx-xxx") .
-                             " Localidade'.</div>");
+                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"xxxxx-xxx":"xxxx-xxx Localidade") .
+                             "'.</div>");
                         $inputs_invalidos = true;
                 }
 	  	

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -307,7 +307,7 @@ $pageUI->addWidget($footer);
                         <div class="col-lg-4">
                         <div id="codigo_postal_div">
                           <label for="codigo_postal">Código postal:</label>
-                          <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx Localidade':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
+                          <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
                           <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
                         </div>
                         </div>
@@ -778,7 +778,7 @@ function validar()
         
         if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx' ?> Localidade'.");
+                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>'.");
                 return false;
         }
                 


### PR DESCRIPTION
## Summary
- allow optional locality for Brazilian zip codes
- adjust form placeholders and messages for BR locale

## Testing
- `php -l core/DataValidationUtils.php`
- `php -l processarInscricao.php`
- `php -l publico/doInscrever.php`
- `php -l mostrarPedidoInscricao.php`
- `php -l inscricao.php`
- `php -l publico/inscrever.php`
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812e4b69c48328b72fd066d521c00c