### PR TITLE
Update spelling in registration forms

### DIFF
--- a/inscricao.php
+++ b/inscricao.php
@@ -237,7 +237,7 @@ $menu->renderHTML();
     <div class="form-group">
     <div class="col-xs-8">
     <div class="row" style="margin-top:20px; "></div>
-    	<label for="e_baptizado">É baptizado(a):</label>
+        <label for="e_baptizado">É batizado(a):</label>
     	<label class="radio-inline"><input type="radio" id="baptizado1" name="baptizado" value="Sim" <?php  if($_REQUEST['modo']=='regresso' && $_SESSION['baptizado']=='Sim'){ echo('checked');} ?>>Sim</label>
 	<label class="radio-inline"><input type="radio" id="baptizado2" name="baptizado" value="Nao" <?php  if($_REQUEST['modo']!='regresso' || ($_REQUEST['modo']=='regresso' && $_SESSION['baptizado']!='Sim')){ echo('checked');} ?>>Não</label>
     </div>
@@ -250,8 +250,8 @@ $menu->renderHTML();
     <?php if($_REQUEST['modo']=='editar'){ echo("<!--");} ?>
     <div class="form-group collapse <?php  if($_REQUEST['modo']=='regresso' && $_SESSION['baptizado']=='Sim'){ echo('in');} ?>" id="paroquia_baptismo_collapse">
     <div class="col-xs-4">
-      <label for="paroquia_baptismo"> Paróquia de baptismo: </label>
-      <input type="text" class="form-control" id="paroquia_baptismo" name="paroquia_baptismo" placeholder="Paróquia de baptismo" list="paroquias" value="<?php  if($_REQUEST['modo']=='regresso'){ echo('' . $_SESSION['paroquia_baptismo'] . '');} else {echo('');} ?>">
+      <label for="paroquia_baptismo"> Paróquia de batismo: </label>
+      <input type="text" class="form-control" id="paroquia_baptismo" name="paroquia_baptismo" placeholder="Paróquia de batismo" list="paroquias" value="<?php  if($_REQUEST['modo']=='regresso'){ echo('' . $_SESSION['paroquia_baptismo'] . '');} else {echo('');} ?>">
     </div>
      <?php if($_REQUEST['modo']=='editar'){ echo("-->");} ?>
     
@@ -742,19 +742,19 @@ function validar()
         <?php if($_REQUEST['modo']!='editar') :?>
         if( baptizado && (paroquia_baptismo=="" || paroquia_baptismo==undefined))
         {
-        	alert("Deve especificar a paróquia de baptismo.");
+                alert("Deve especificar a paróquia de batismo.");
 		return false; 
         }
         
         if( baptizado && (data_baptismo=="" || data_baptismo==undefined))
         {
-        	alert("Deve especificar a data de baptismo.");
+                alert("Deve especificar a data de batismo.");
 		return false; 
         }
         
         if( baptizado && !data_valida(data_baptismo))
         {
-        	alert("A data de baptismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.");
+                alert("A data de batismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.");
 		return false; 
         }
         

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -418,7 +418,7 @@ $db = new PdoDatabaseManager();
             <div class="form-group">
             <div class="col-lg-8">
             <div class="row" style="margin-top:20px; "></div>
-                <label for="e_baptizado">É baptizado(a):</label>
+                <label for="e_baptizado">É batizado(a):</label>
                 <label class="radio-inline"><input type="radio" id="baptizado1" name="baptizado" value="Sim" <?php  if($baptizado){ echo('checked');}else{echo("disabled");} ?> readonly>Sim</label>
             <label class="radio-inline"><input type="radio" id="baptizado2" name="baptizado" value="Nao" <?php  if(!$baptizado){ echo('checked');}else{echo("disabled");} ?> readonly>Não</label>
             </div>
@@ -429,8 +429,8 @@ $db = new PdoDatabaseManager();
             <!--paroquia de baptismo-->
             <div class="form-group collapse <?php  if($baptizado){ echo('in');} ?>" id="paroquia_baptismo_collapse">
             <div class="col-lg-4">
-              <label for="paroquia_baptismo"> Paróquia de baptismo: </label>
-              <input type="text" class="form-control" id="paroquia_baptismo" name="paroquia_baptismo" placeholder="Paróquia de baptismo"  value="<?php echo($submission['paroquia_baptismo']);?>" readonly>
+              <label for="paroquia_baptismo"> Paróquia de batismo: </label>
+              <input type="text" class="form-control" id="paroquia_baptismo" name="paroquia_baptismo" placeholder="Paróquia de batismo"  value="<?php echo($submission['paroquia_baptismo']);?>" readonly>
             </div>
 
 
@@ -813,19 +813,19 @@ function validar()
         <?php if($_REQUEST['modo']!='editar') :?>
         if( baptizado && (paroquia_baptismo==="" || paroquia_baptismo===undefined))
         {
-        	alert("Deve especificar a paróquia de baptismo.");
+            alert("Deve especificar a paróquia de batismo.");
 		return false; 
         }
         
         if( baptizado && (data_baptismo==="" || data_baptismo===undefined))
         {
-        	alert("Deve especificar a data de baptismo.");
+            alert("Deve especificar a data de batismo.");
 		return false; 
         }
         
         if( baptizado && !data_valida(data_baptismo))
         {
-        	alert("A data de baptismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.");
+            alert("A data de batismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.");
 		return false; 
         }
         

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -330,13 +330,13 @@ $menu->renderHTML();
 	  	
 	  	if($baptizado && !DataValidationUtils::validateDate($data_baptismo))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> A data de baptismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.</div>");
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> A data de batismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	
 	  	if($baptizado && (!$paroquia_baptismo || $paroquia_baptismo==""))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> Deve especificar a paróquia de baptismo.</div>");
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> Deve especificar a paróquia de batismo.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -343,13 +343,13 @@ $navbar->renderHTML();
 	  	
 	  	if($baptizado==1 && !DataValidationUtils::validateDate($data_baptismo))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> A data de baptismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.</div>");
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> A data de batismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	
 	  	if($baptizado==1 && (!$paroquia_baptismo || $paroquia_baptismo==""))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> Deve especificar a paróquia de baptismo.</div>");
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> Deve especificar a paróquia de batismo.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -396,7 +396,7 @@ $pageUI->addWidget($footer);
                     <?php if($_REQUEST['modo']=='editar'){ echo("<!--");} ?>
                     <div class="form-group">
                         <div class="col-lg-8">
-                            <label for="e_baptizado">É baptizado(a):</label>
+                            <label for="e_baptizado">É batizado(a):</label>
                             <label class="radio-inline"><input type="radio" id="baptizado1" name="baptizado" value="Sim" <?php  if($_REQUEST['modo']=='regresso' && $_SESSION['baptizado']=='Sim'){ echo('checked');} ?>>Sim</label>
                             <label class="radio-inline"><input type="radio" id="baptizado2" name="baptizado" value="Nao" <?php  if($_REQUEST['modo']!='regresso' || ($_REQUEST['modo']=='regresso' && $_SESSION['baptizado']!='Sim')){ echo('checked');} ?>>Não</label>
                         </div>
@@ -409,8 +409,8 @@ $pageUI->addWidget($footer);
                     <?php if($_REQUEST['modo']=='editar'){ echo("<!--");} ?>
                     <div class="form-group collapse <?php  if($_REQUEST['modo']=='regresso' && $_SESSION['baptizado']=='Sim'){ echo('in');} ?>" id="paroquia_baptismo_collapse">
                         <div class="col-lg-4">
-                          <label for="paroquia_baptismo"> Paróquia de baptismo: </label>
-                          <input type="text" class="form-control" id="paroquia_baptismo" name="paroquia_baptismo" placeholder="Paróquia de baptismo"  value="<?php  if($_REQUEST['modo']=='regresso'){ echo('' . $_SESSION['paroquia_baptismo'] . '');} else {echo('');} ?>">
+                          <label for="paroquia_baptismo"> Paróquia de batismo: </label>
+                          <input type="text" class="form-control" id="paroquia_baptismo" name="paroquia_baptismo" placeholder="Paróquia de batismo"  value="<?php  if($_REQUEST['modo']=='regresso'){ echo('' . $_SESSION['paroquia_baptismo'] . '');} else {echo('');} ?>">
                         </div>
                          <?php if($_REQUEST['modo']=='editar'){ echo("-->");} ?>
 
@@ -804,19 +804,19 @@ function validar()
         <?php if($_REQUEST['modo']!='editar') :?>
         if( baptizado && (paroquia_baptismo==="" || paroquia_baptismo===undefined))
         {
-        	alert("Deve especificar a paróquia de baptismo.");
+                alert("Deve especificar a paróquia de batismo.");
 		return false; 
         }
         
         if( baptizado && (data_baptismo==="" || data_baptismo===undefined))
         {
-        	alert("Deve especificar a data de baptismo.");
+                alert("Deve especificar a data de batismo.");
 		return false; 
         }
         
         if( baptizado && !data_valida(data_baptismo))
         {
-        	alert("A data de baptismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.");
+                alert("A data de batismo que introduziu é inválida. Deve ser da forma dd-mm-aaaa.");
 		return false; 
         }
         


### PR DESCRIPTION
## Summary
- replace old spelling 'baptismo' and 'baptizado' with 'batismo' and 'batizado'
- update labels, placeholders, and alerts in registration-related forms

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6881386a7f1883289b53d4f10089ce51