### PR TITLE
Fix date validation shared regex

### DIFF
--- a/criarCatequeseVirtual.php
+++ b/criarCatequeseVirtual.php
@@ -506,6 +506,7 @@ quill_render_js_scripts();
 <script src="js/quill-1.3.6/quill.min.js"></script>
 <script src="js/quill-image-resize-module/image-resize.min.js"></script>
 <script src="js/bootoast-1.0.1/bootoast.js"></script>
+<script src="js/form-validation-utils.js"></script>
 
 <script>
 
@@ -716,13 +717,6 @@ $(function(){
 
 
 <script>
-function data_valida(data)
-{
-	var pattern = /^[0-9]{1,2}\-[0-9]{1,2}\-[0-9]{4}$/;
-	
-	return (pattern.test(data));
-
-}
 
 
 function verifica_data()

--- a/inscricao.php
+++ b/inscricao.php
@@ -594,6 +594,7 @@ $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
 <script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<script src="js/form-validation-utils.js"></script>
 <script type="text/javascript" src="webcamjs-master/webcam.js"></script>
 
 <script language="JavaScript">    
@@ -830,13 +831,6 @@ function codigo_postal_valido(codigo, locale)
 }
 
 
-function data_valida(data)
-{
-	var pattern = /^[0-9]{1,2}\-[0-9]{1,2}\-[0-9]{4}$/;
-	
-	return (pattern.test(data));
-
-}
 </script>
 
 

--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -32,6 +32,6 @@ function codigo_postal_valido(codigo, locale)
 
 function data_valida(data)
 {
-    var pattern = /^[0-9]{1,2}\-[0-9]{1,2}\-[0-9]{4}$/;
+    var pattern = /^[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4}$/;
     return (pattern.test(data));
 }

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -749,6 +749,7 @@ $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
 <script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
+<script src="js/form-validation-utils.js"></script>
 
 <script>
 function validar()
@@ -919,13 +920,6 @@ function codigo_postal_valido(codigo, locale)
 }
 
 
-function data_valida(data)
-{
-	var pattern = /^[0-9]{1,2}\-[0-9]{1,2}\-[0-9]{4}$/;
-	
-	return (pattern.test(data));
-
-}
 </script>
 
 

--- a/registarSacramentos.php
+++ b/registarSacramentos.php
@@ -601,6 +601,7 @@ $pageUI->renderJS(); // Render the widgets' JS code
 <script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
 <script src="js/rowlink.js"></script>
 <script src="js/bootstrap-switch.js"></script>
+<script src="js/form-validation-utils.js"></script>
 
 <script>
 	
@@ -698,13 +699,6 @@ $('input[class="checkbox-geral"]').on('switchChange.bootstrapSwitch', function(e
 
 <script>
 
-function data_valida(data)
-{
-	var pattern = /^[0-9]{1,2}\-[0-9]{1,2}\-[0-9]{4}$/;
-	
-	return (pattern.test(data));
-
-}
 
 function verifica_data_sacramento()
 {


### PR DESCRIPTION
## Summary
- update regex for `data_valida` util
- include `form-validation-utils.js` in pages that had local copies
- drop duplicated date validation functions

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68814382f88083289a8442e4e3fd9298