### PR TITLE
Add phone and CEP masks for BR pages

### DIFF
--- a/criarUtilizador.php
+++ b/criarUtilizador.php
@@ -238,6 +238,16 @@ $menu->renderHTML();
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
+<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
+<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script>
+$(function(){
+    $('#telefone').mask('(00) 0000-0000');
+    $('#telemovel').mask('(00) 0 0000-0000');
+    $('#codigo_postal').mask('00000-000');
+});
+</script>
+<?php endif; ?>
 
 <?php
 

--- a/inscricao.php
+++ b/inscricao.php
@@ -592,6 +592,16 @@ $menu->renderHTML();
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
+<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
+<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script>
+$(function(){
+    $('#telefone').mask('(00) 0000-0000');
+    $('#telemovel').mask('(00) 0 0000-0000');
+    $('#codigo_postal').mask('00000-000');
+});
+</script>
+<?php endif; ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
 <script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
 <script type="text/javascript" src="webcamjs-master/webcam.js"></script>

--- a/mostrarAutorizacoes.php
+++ b/mostrarAutorizacoes.php
@@ -758,6 +758,16 @@ HTML_CODE
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
+<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
+<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script>
+$(function(){
+    $('#telefone').mask('(00) 0000-0000');
+    $('#telemovel').mask('(00) 0 0000-0000');
+    $('#codigo_postal').mask('00000-000');
+});
+</script>
+<?php endif; ?>
 <script src="js/bootstrap-switch.js"></script>
 
 <script>

--- a/mostrarFicha.php
+++ b/mostrarFicha.php
@@ -763,9 +763,20 @@ $printDialog->renderHTML();
 
 
 
+
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
+<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
+<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script>
+$(function(){
+    $('#telefone').mask('(00) 0000-0000');
+    $('#telemovel').mask('(00) 0 0000-0000');
+    $('#codigo_postal').mask('00000-000');
+});
+</script>
+<?php endif; ?>
 
 <script type="text/javascript">
 

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -747,6 +747,16 @@ if(!isset($submission['cid']))
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
+<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
+<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script>
+$(function(){
+    $('#telefone').mask('(00) 0000-0000');
+    $('#telemovel').mask('(00) 0 0000-0000');
+    $('#codigo_postal').mask('00000-000');
+});
+</script>
+<?php endif; ?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
 <script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
 

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -665,6 +665,16 @@ $footer->renderHTML();
 
 
 <?php $pageUI->renderJS(); ?>
+<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
+<script src="../js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script>
+$(function(){
+    $('#telefone').mask('(00) 0000-0000');
+    $('#telemovel').mask('(00) 0 0000-0000');
+    $('#codigo_postal').mask('00000-000');
+});
+</script>
+<?php endif; ?>
 <script src="../js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
 <script src="../js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
 <script type="text/javascript" src="../webcamjs-master/webcam.js"></script>


### PR DESCRIPTION
## Summary
- include jquery.mask.min.js wherever phone or postal fields appear
- apply masks for Brazilian locale only

## Testing
- `php -l inscricao.php`
- `php -l mostrarPedidoInscricao.php`
- `php -l publico/inscrever.php`
- `php -l mostrarFicha.php`
- `php -l criarUtilizador.php`
- `php -l mostrarAutorizacoes.php`

------
https://chatgpt.com/codex/tasks/task_e_68814385a2808328a901da531dbb34be