### PR TITLE
Fix BR phone validation

### DIFF
--- a/core/DataValidationUtils.php
+++ b/core/DataValidationUtils.php
@@ -48,16 +48,23 @@ class DataValidationUtils
             $antipattern1 = "000000000";
             $antipattern2 = "111111111";
             $antipattern3 = "123456789";
+            $match = preg_match($pattern, $tel);
         }
         else if($locale==Locale::BRASIL)
         {
-            $pattern = '/^(\+\d{1,}[-\s]{0,1})?\s*\(?(\d{2}|\d{0})\)?[-. ]?(\d{5}|\d{4})[-. ]?(\d{4})[-. ]?\s*$/';
+            $mobilePattern = '/^(\+\d{1,}[-\s]{0,1})?\s*\(?(\d{2}|\d{0})\)?[-. ]?9\d{4}[-. ]?\d{4}\s*$/';
+            $landlinePattern = '/^(\+\d{1,}[-\s]{0,1})?\s*\(?(\d{2}|\d{0})\)?[-. ]?\d{4}[-. ]?\d{4}\s*$/';
             $antipattern1 = "0000-0000";
             $antipattern2 = "1111-1111";
             $antipattern3 = "1234-5678";
+            $match = preg_match($mobilePattern, $tel) || preg_match($landlinePattern, $tel);
+        }
+        else
+        {
+            $match = false;
         }
 
-        return preg_match($pattern, $tel) && (!$checkAntiPatterns ||
+        return $match && (!$checkAntiPatterns ||
                 (strpos($tel, $antipattern1)===false && strpos($tel, $antipattern2)===false && strpos($tel, $antipattern3)===false));
     }
 

--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -1,14 +1,18 @@
 
 function telefone_valido(num, locale)
 {
-    var phoneno = '';
+    if(locale === "PT")
+    {
+        return /^(\+\d{1,}[-\s]{0,1})?\d{9}$/.test(num);
+    }
+    else if(locale === "BR")
+    {
+        const mobile = /^(\+\d{1,}[-\s]{0,1})?\s*\(?(\d{2}|\d{0})\)?[-. ]?9\d{4}[-. ]?\d{4}\s*$/;
+        const landline = /^(\+\d{1,}[-\s]{0,1})?\s*\(?(\d{2}|\d{0})\)?[-. ]?\d{4}[-. ]?\d{4}\s*$/;
+        return mobile.test(num) || landline.test(num);
+    }
 
-    if(locale==="PT")
-        phoneno = /^(\+\d{1,}[-\s]{0,1})?\d{9}$/;
-    else if(locale==="BR")
-        phoneno = /^(\+\d{1,}[-\s]{0,1})?\s*\(?(\d{2}|\d{0})\)?[-. ]?(\d{5}|\d{4})[-. ]?(\d{4})[-. ]?\s*$/;
-
-    return !!num.match(phoneno);
+    return false;
 }
 
 function email_valido(email)


### PR DESCRIPTION
## Summary
- enforce ninth digit for Brazilian mobile numbers in `DataValidationUtils`
- mirror validation logic in `form-validation-utils.js`

## Testing
- `php -l core/DataValidationUtils.php`
- `node -e "require('./js/form-validation-utils.js');"`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881438686188328be3900063ccc0eab