### PR TITLE
Fix BR masks for phone and CEP

### DIFF
--- a/criarUtilizador.php
+++ b/criarUtilizador.php
@@ -240,11 +240,10 @@ $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
 <script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script src="js/form-mask-utils.js"></script>
 <script>
 $(function(){
-    $('#telefone').mask('(00) 0000-0000');
-    $('#telemovel').mask('(00) 0 0000-0000');
-    $('#codigo_postal').mask('00000-000');
+    applyBrazilianMasks();
 });
 </script>
 <?php endif; ?>

--- a/inscricao.php
+++ b/inscricao.php
@@ -183,7 +183,7 @@ $menu->renderHTML();
     <div class="col-xs-4">
     <div id="codigo_postal_div">
       <label for="codigo_postal"><?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'CEP' : 'Código postal' ?></label>
-      <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>" list="codigos_postais" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
+      <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'00000-000':'xxxx-xxx Localidade' ?>" list="codigos_postais" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
       <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
     </div>
     </div>
@@ -594,11 +594,10 @@ $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
 <script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script src="js/form-mask-utils.js"></script>
 <script>
 $(function(){
-    $('#telefone').mask('(00) 0000-0000');
-    $('#telemovel').mask('(00) 0 0000-0000');
-    $('#codigo_postal').mask('00000-000');
+    applyBrazilianMasks();
 });
 </script>
 <?php endif; ?>
@@ -717,7 +716,7 @@ function validar()
         
     if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
-        alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>'.");
+        alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'00000-000':'xxxx-xxx Localidade' ?>'.");
         return false;
     }
         

--- a/js/form-mask-utils.js
+++ b/js/form-mask-utils.js
@@ -1,0 +1,14 @@
+function applyBrazilianMasks() {
+    if (typeof $ === 'undefined' || typeof $.fn.mask !== 'function') {
+        return;
+    }
+    $('#telefone').mask('(00) 0000-0000');
+    $('#codigo_postal').mask('00000-000');
+    $('#telemovel').mask('(00) Z 0000-0000', {
+        translation: {
+            'Z': { pattern: /9/ },
+            '0': { pattern: /[0-9]/ }
+        }
+    });
+}
+

--- a/mostrarAutorizacoes.php
+++ b/mostrarAutorizacoes.php
@@ -760,11 +760,10 @@ $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
 <script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script src="js/form-mask-utils.js"></script>
 <script>
 $(function(){
-    $('#telefone').mask('(00) 0000-0000');
-    $('#telemovel').mask('(00) 0 0000-0000');
-    $('#codigo_postal').mask('00000-000');
+    applyBrazilianMasks();
 });
 </script>
 <?php endif; ?>

--- a/mostrarFicha.php
+++ b/mostrarFicha.php
@@ -769,11 +769,10 @@ $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
 <script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script src="js/form-mask-utils.js"></script>
 <script>
 $(function(){
-    $('#telefone').mask('(00) 0000-0000');
-    $('#telemovel').mask('(00) 0 0000-0000');
-    $('#codigo_postal').mask('00000-000');
+    applyBrazilianMasks();
 });
 </script>
 <?php endif; ?>

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -309,7 +309,7 @@ $db = new PdoDatabaseManager();
                 <div class="col-lg-4">
                 <div id="codigo_postal_div">
                   <label for="codigo_postal"><?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'CEP' : 'Código postal' ?></label>
-                  <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php echo($submission['cod_postal']);?>" readonly required>
+                  <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'00000-000':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php echo($submission['cod_postal']);?>" readonly required>
                   <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
                 </div>
                 </div>
@@ -749,11 +749,10 @@ $pageUI->renderJS(); // Render the widgets' JS code
 ?>
 <?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
 <script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script src="js/form-mask-utils.js"></script>
 <script>
 $(function(){
-    $('#telefone').mask('(00) 0000-0000');
-    $('#telemovel').mask('(00) 0 0000-0000');
-    $('#codigo_postal').mask('00000-000');
+    applyBrazilianMasks();
 });
 </script>
 <?php endif; ?>
@@ -798,7 +797,7 @@ function validar()
         
         if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>'.");
+                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'00000-000':'xxxx-xxx Localidade' ?>'.");
                 return false;
         }
                 

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -308,7 +308,7 @@ $menu->renderHTML();
                 if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
                 {
                         echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma '" .
-                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"xxxxx-xxx":"xxxx-xxx Localidade") .
+                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"00000-000":"xxxx-xxx Localidade") .
                              "'.</div>");
                         var_dump($codigo_postal);
                         $inputs_invalidos = true;
@@ -317,13 +317,13 @@ $menu->renderHTML();
 	  	
 	  	if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
+	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve estar no formato '(99) 9999-9999'.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	
 	  	if($telemovel!="" && !DataValidationUtils::validatePhoneNumber($telemovel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
+	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de celular que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -322,7 +322,7 @@ $navbar->renderHTML();
                 if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
                 {
                         echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma '" .
-                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"xxxxx-xxx":"xxxx-xxx Localidade") .
+                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"00000-000":"xxxx-xxx Localidade") .
                              "'.</div>");
                         $inputs_invalidos = true;
                 }
@@ -330,13 +330,13 @@ $navbar->renderHTML();
 	  	
 	  	if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
+	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve estar no formato '(99) 9999-9999'.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	
 	  	if($telemovel!="" && !DataValidationUtils::validatePhoneNumber($telemovel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telemóvel que introduziu é inválido. Deve conter 9 dígitos ou iniciar-se com '+xxx ' seguido de 9 digitos.</div>");
+	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de celular que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -307,7 +307,7 @@ $pageUI->addWidget($footer);
                         <div class="col-lg-4">
                         <div id="codigo_postal_div">
                           <label for="codigo_postal"><?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'CEP' : 'Código postal' ?></label>
-                          <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
+                          <input type="text" class="form-control" id="codigo_postal" name="codigo_postal" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'00000-000':'xxxx-xxx Localidade' ?>" onclick="verifica_codigo_postal()" onchange="verifica_codigo_postal()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['cod_postal'] . '');} else {echo('');} ?>" required>
                           <span id="erro_postal_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
                         </div>
                         </div>
@@ -667,11 +667,10 @@ $footer->renderHTML();
 <?php $pageUI->renderJS(); ?>
 <?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
 <script src="../js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script src="../js/form-mask-utils.js"></script>
 <script>
 $(function(){
-    $('#telefone').mask('(00) 0000-0000');
-    $('#telemovel').mask('(00) 0 0000-0000');
-    $('#codigo_postal').mask('00000-000');
+    applyBrazilianMasks();
 });
 </script>
 <?php endif; ?>
@@ -788,7 +787,7 @@ function validar()
         
         if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'xxxxx-xxx':'xxxx-xxx Localidade' ?>'.");
+                alert("O código postal que introduziu é inválido. Deve ser da forma '<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'00000-000':'xxxx-xxx Localidade' ?>'.");
                 return false;
         }
                 


### PR DESCRIPTION
## Summary
- add `form-mask-utils.js` for reusable masking logic
- update PHP pages to use the helper and enforce `(99) 9 9999-9999` mobile format
- adjust placeholders and error messages for Brazilian CEP format

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688141316c4483289fb851db1fdf7569