### PR TITLE
Update phone field placeholder and mask

### DIFF
--- a/mostrarAutorizacoes.php
+++ b/mostrarAutorizacoes.php
@@ -683,7 +683,7 @@ $menu->renderHTML();
                                     <div class="input-group input-group-sm"><input type="text" class="form-control" id="nome_familiar" name="nome_familiar" placeholder="Nome" list="nomes_familiares" required></div></div></td>
                             <td><div class="input-group input-group-sm"><input type="text" class="form-control" id="parentesco" name="parentesco" placeholder="Avó" list="parentescos_familiares" required></div></td>
                             <td><div class="btn-group-xs" role="group" aria-label="...">
-                                    <div class="input-group input-group-sm"><input type="text" class="form-control" id="telemovel" name="telemovel" placeholder="9xxxxxxxx" list="" required></div></div></td>
+                                    <div class="input-group input-group-sm"><input type="text" class="form-control" id="telemovel" name="telemovel" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'(65) 99800-1234':'' ?>" list="" required></div></div></td>
                             <td><div class="btn-group-xs" role="group" aria-label="...">
                                     <button type="submit" class="btn btn-default pull-right"><span class="glyphicon glyphicon-plus text-success">Adicionar</span></button>
                                 </div></td>
@@ -764,6 +764,7 @@ $pageUI->renderJS(); // Render the widgets' JS code
 <script>
 $(function(){
     applyBrazilianMasks();
+    $('#telemovel').mask('(00) 9 0000-0000');
 });
 </script>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- tweak placeholder for 'telemovel' example
- ensure jQuery mask runs for the phone field

## Testing
- `phpunit --version` *(fails: command not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68814edc90948328965b04355be5df43