### PR TITLE
Update alerts for BR locale wording

### DIFF
--- a/inscricao.php
+++ b/inscricao.php
@@ -719,10 +719,10 @@ function validar()
         return false;
     }
         
-    if( (telefone=="" || telefone==undefined) && (telemovel=="" || telemovel==undefined) ) 
+    if( (telefone=="" || telefone==undefined) && (telemovel=="" || telemovel==undefined) )
     {
-        alert("Deve introduzir pelo menos um número de telefone ou telemóvel.");
-        return false; 
+        alert("Deve introduzir pelo menos um número de telefone ou <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?>.");
+        return false;
     }
     else if(telefone!="" && telefone!=undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
@@ -731,8 +731,8 @@ function validar()
     }
     else if(telemovel!="" && telemovel!=undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
-        alert("O número de telemóvel que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
-        return false; 
+        alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
+        return false;
     }
 
     <?php if($_REQUEST['modo']!='editar') :?>

--- a/mostrarAutorizacoes.php
+++ b/mostrarAutorizacoes.php
@@ -350,7 +350,9 @@ $menu->renderHTML();
                 }
                 if($telemovel_familiar=="" || !DataValidationUtils::validatePhoneNumber($telemovel_familiar, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
                 {
-                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telemóvel que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.</div>");
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de "
+                        . ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'celular' : 'telemóvel')
+                        . " que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.</div>");
                     $inputs_invalidos = true;
                 }
 
@@ -778,7 +780,7 @@ function valida_dados_familiar()
     var telemovel = document.getElementById('telemovel').value;
     if(!telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
-        alert("O número de telemóvel que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
+        alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
         return false;
     }
     return true;

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -805,8 +805,8 @@ function validar()
         
         if((telefone==="" || telefone===undefined) && (telemovel==="" || telemovel===undefined) )
         {
-		alert("Deve introduzir pelo menos um número de telefone ou telemóvel.");
-		return false; 
+                alert("Deve introduzir pelo menos um número de telefone ou <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?>.");
+                return false;
         }
         else if(telefone!=="" && telefone!==undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
@@ -815,8 +815,8 @@ function validar()
         }
         else if(telemovel!=="" && telemovel!==undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O número de telemóvel que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
-		return false; 
+                alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
+                return false;
         }
         
         

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -795,8 +795,8 @@ function validar()
         
         if((telefone==="" || telefone===undefined) && (telemovel==="" || telemovel===undefined) )
         {
-		alert("Deve introduzir pelo menos um número de telefone ou telemóvel.");
-		return false; 
+                alert("Deve introduzir pelo menos um número de telefone ou <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?>.");
+                return false;
         }
         else if(telefone!=="" && telefone!==undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
@@ -805,8 +805,8 @@ function validar()
         }
         else if(telemovel!=="" && telemovel!==undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O número de telemóvel que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
-		return false; 
+                alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
+                return false;
         }
         
         


### PR DESCRIPTION
## Summary
- adjust alerts to use "celular" for BR localization
- keep "telemóvel" for PT localization

## Testing
- `phpunit -v` *(fails: command not found)*
- `vendor/bin/phpunit -v` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688155f2c3dc83289b7970e7eb9351e3