### PR TITLE
Update invalid CEP message by locale

### DIFF
--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -31,6 +31,7 @@ use core\domain\Sacraments;
 use catechesis\gui\WidgetManager;
 use catechesis\gui\MainNavbar;
 use catechesis\gui\MainNavbar\MENU_OPTION;
+use core\domain\Locale;
 
 // Default to no special mode if none was specified
 if (!isset($_REQUEST['modo']))
@@ -307,9 +308,13 @@ $menu->renderHTML();
 	  		  	
                 if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
                 {
-                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma '" .
-                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"00000-000":"xxxx-xxx Localidade") .
-                             "'.</div>");
+                        $locale = Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE);
+                        if($locale == Locale::BRASIL)
+                            $msg = "O CEP que você introduziu é inválido. Deve ser da forma '99999-999'.";
+                        else
+                            $msg = "O código postal que introduziu é inválido. Deve ser da forma 'xxxx-xxx Localidade'.";
+
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> $msg</div>");
                         var_dump($codigo_postal);
                         $inputs_invalidos = true;
                 }

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -25,6 +25,7 @@ use catechesis\gui\WidgetManager;
 use catechesis\gui\MinimalNavbar;
 use catechesis\gui\SimpleFooter;
 use catechesis\PixQRCode;
+use core\domain\Locale;
 
 $db = new PdoDatabaseManager();
 
@@ -321,9 +322,13 @@ $navbar->renderHTML();
 	  		  	
                 if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
                 {
-                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O código postal que introduziu é inválido. Deve ser da forma '" .
-                             ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"00000-000":"xxxx-xxx Localidade") .
-                             "'.</div>");
+                        $locale = Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE);
+                        if($locale == Locale::BRASIL)
+                            $msg = "O CEP que você introduziu é inválido. Deve ser da forma '99999-999'.";
+                        else
+                            $msg = "O código postal que introduziu é inválido. Deve ser da forma 'xxxx-xxx Localidade'.";
+
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> $msg</div>");
                         $inputs_invalidos = true;
                 }
 	  	


### PR DESCRIPTION
## Summary
- show Brazilian CEP message if locale is BR
- keep Portuguese postal code message otherwise

## Testing
- `php -l processarInscricao.php`
- `php -l publico/doInscrever.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688155f467908328a92782363f1182f3