### PR TITLE
Refactor Brazilian mask scripts into shared include

### DIFF
--- a/criarUtilizador.php
+++ b/criarUtilizador.php
@@ -238,15 +238,9 @@ $menu->renderHTML();
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
-<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
-<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
-<script src="js/form-mask-utils.js"></script>
-<script>
-$(function(){
-    applyBrazilianMasks();
-});
-</script>
-<?php endif; ?>
+<?php
+    include __DIR__ . '/includes/brazilian_masks.php';
+?>
 
 <?php
 

--- a/includes/brazilian_masks.php
+++ b/includes/brazilian_masks.php
@@ -1,0 +1,19 @@
+<?php
+// Include jQuery mask plugin and apply default Brazilian input masks when locale is BR
+
+// Optionally specify $maskPathPrefix before including this file to adjust the
+// relative path of the JS files. Default is an empty string which works for
+// files in the project root.
+if (!isset($maskPathPrefix)) {
+    $maskPathPrefix = '';
+}
+?>
+<?php if (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
+<script src="<?= $maskPathPrefix ?>js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
+<script src="<?= $maskPathPrefix ?>js/form-mask-utils.js"></script>
+<script>
+$(function(){
+    applyBrazilianMasks();
+});
+</script>
+<?php endif; ?>

--- a/inscricao.php
+++ b/inscricao.php
@@ -611,15 +611,10 @@ $menu->renderHTML();
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
-<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
-<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
-<script src="js/form-mask-utils.js"></script>
-<script>
-$(function(){
-    applyBrazilianMasks();
-});
-</script>
-<?php endif; ?>
+<?php
+    // Output JS for applying Brazilian input masks when running in BR locale
+    include __DIR__ . '/includes/brazilian_masks.php';
+?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
 <script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
 <script src="js/form-validation-utils.js"></script>

--- a/mostrarAutorizacoes.php
+++ b/mostrarAutorizacoes.php
@@ -760,12 +760,12 @@ HTML_CODE
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
+<?php
+    include __DIR__ . '/includes/brazilian_masks.php';
+?>
 <?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
-<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
-<script src="js/form-mask-utils.js"></script>
 <script>
 $(function(){
-    applyBrazilianMasks();
     $('#telemovel').mask('(00) 9 0000-0000');
 });
 </script>

--- a/mostrarFicha.php
+++ b/mostrarFicha.php
@@ -767,15 +767,9 @@ $printDialog->renderHTML();
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
-<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
-<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
-<script src="js/form-mask-utils.js"></script>
-<script>
-$(function(){
-    applyBrazilianMasks();
-});
-</script>
-<?php endif; ?>
+<?php
+    include __DIR__ . '/includes/brazilian_masks.php';
+?>
 
 <script type="text/javascript">
 

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -754,15 +754,9 @@ if(!isset($submission['cid']))
 <?php
 $pageUI->renderJS(); // Render the widgets' JS code
 ?>
-<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
-<script src="js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
-<script src="js/form-mask-utils.js"></script>
-<script>
-$(function(){
-    applyBrazilianMasks();
-});
-</script>
-<?php endif; ?>
+<?php
+    include __DIR__ . '/includes/brazilian_masks.php';
+?>
 <script src="js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
 <script src="js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
 <script src="js/form-validation-utils.js"></script>

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -666,15 +666,10 @@ $footer->renderHTML();
 
 
 <?php $pageUI->renderJS(); ?>
-<?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
-<script src="../js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
-<script src="../js/form-mask-utils.js"></script>
-<script>
-$(function(){
-    applyBrazilianMasks();
-});
-</script>
-<?php endif; ?>
+<?php
+    $maskPathPrefix = '../';
+    include __DIR__ . '/../includes/brazilian_masks.php';
+?>
 <script src="../js/bootstrap-datepicker-1.9.0-dist/js/bootstrap-datepicker.min.js"></script>
 <script src="../js/bootstrap-datepicker-1.9.0-dist/locales/bootstrap-datepicker.pt.min.js"></script>
 <script type="text/javascript" src="../webcamjs-master/webcam.js"></script>

--- a/publico/renovarMatricula.php
+++ b/publico/renovarMatricula.php
@@ -218,12 +218,13 @@ $footer->renderHTML();
 
 
 <?php $pageUI->renderJS(); ?>
+<?php
+    $maskPathPrefix = '../';
+    include __DIR__ . '/../includes/brazilian_masks.php';
+?>
 <?php if(Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL): ?>
-<script src="../js/jQuery-Mask-Plugin-1.14.16/jquery.mask.min.js"></script>
-<script src="../js/form-mask-utils.js"></script>
 <script>
 $(function(){
-    applyBrazilianMasks();
     $('#enc_edu_tel').mask('(00) 0000-0000');
 });
 </script>


### PR DESCRIPTION
## Summary
- create reusable `includes/brazilian_masks.php`
- use new include in pages using Brazilian input masks

## Testing
- `php -l includes/brazilian_masks.php`
- `php -l inscricao.php`
- `php -l publico/inscrever.php`
- `php -l publico/renovarMatricula.php`
- `php -l mostrarAutorizacoes.php`
- `php -l mostrarFicha.php`
- `php -l mostrarPedidoInscricao.php`
- `php -l criarUtilizador.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68828e1c002c8328a00fc4a946117a06