### PR TITLE
Ajusta formulários para dados brasileiros

### DIFF
--- a/core/DataValidationUtils.php
+++ b/core/DataValidationUtils.php
@@ -52,7 +52,7 @@ class DataValidationUtils
         }
         else if($locale==Locale::BRASIL)
         {
-            $mobilePattern = '/^\(\d{2}\) 9 \d{4}-\d{4}$/';
+            $mobilePattern = '/^\(\d{2}\) 9\d{4}-\d{4}$/';
             $landlinePattern = '/^\(\d{2}\) \d{4}-\d{4}$/';
             $antipattern1 = "0000-0000";
             $antipattern2 = "1111-1111";

--- a/inscricao.php
+++ b/inscricao.php
@@ -191,7 +191,7 @@ $menu->renderHTML();
             $codigo_postal_list_attr = ' list="codigos_postais"';
         }
         $placeholder = (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)
-            ? 'Ex: 78015-085'
+            ? '00000-000'
             : 'xxxx-xxx Localidade';
       ?>
       <input type="text" class="form-control" id="codigo_postal" name="codigo_postal"
@@ -213,7 +213,7 @@ $menu->renderHTML();
     <div class="col-xs-2">
     <div id="telefone_div">
       <label for="tel">Telefone:</label>
-      <input type="tel" class="form-control" id="telefone" name="telefone" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'Ex: (65) 3322-7788':'Telefone do responsável legal' ?>" onclick="verifica_telefone()" onchange="verifica_telefone()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['telefone'] . '');} else {echo('');} ?>">
+      <input type="tel" class="form-control" id="telefone" name="telefone" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'Ex: (65) 3333-4444':'Telefone do responsável legal' ?>" onclick="verifica_telefone()" onchange="verifica_telefone()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['telefone'] . '');} else {echo('');} ?>">
       <span id="erro_telefone_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
     </div>
     </div>
@@ -224,7 +224,7 @@ $menu->renderHTML();
     <div class="col-xs-2">
     <div id="telemovel_div">
       <label for="telm"><?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?"Celular":"Telemóvel" ?>:</label>
-      <input type="tel" class="form-control" id="telemovel" name="telemovel" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'Ex: (65) 99800-3774':'Telemóvel do responsável legal' ?>" onclick="verifica_telemovel()" onchange="verifica_telemovel()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['telemovel'] . '');} else {echo('');} ?>">
+      <input type="tel" class="form-control" id="telemovel" name="telemovel" placeholder="<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'Ex: (65) 91234-5678':'Telemóvel do responsável legal' ?>" onclick="verifica_telemovel()" onchange="verifica_telemovel()" value="<?php  if($_REQUEST['modo']=='irmao' || $_REQUEST['modo']=='regresso' || $_REQUEST['modo']=='editar'){ echo('' . $_SESSION['telemovel'] . '');} else {echo('');} ?>">
       <span id="erro_telemovel_icon" class="glyphicon glyphicon-remove form-control-feedback" style="display:none;"></span>
     </div>
     <div class="clearfix"></div>
@@ -729,7 +729,7 @@ function validar()
         
     if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
-        alert("<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'O CEP que introduziu é inválido. Deve ser da forma \u002799999-999\u0027.' : 'O código postal que introduziu é inválido. Deve ser da forma \u0027xxxx-xxx Localidade\u0027.' ?>");
+        alert("<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'O CEP que introduziu é inválido. Deve ser da forma \u002700000-000\u0027.' : 'O código postal que introduziu é inválido. Deve ser da forma \u0027xxxx-xxx Localidade\u0027.' ?>");
         return false;
     }
         
@@ -740,12 +740,12 @@ function validar()
     }
     else if(telefone!="" && telefone!=undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
-        alert("O número de telefone que introduziu é inválido. Deve estar no formato '(99) 9999-9999'.");
+        alert("O número de telefone que introduziu é inválido. Deve estar no formato '(99) 3333-4444'.");
         return false; 
     }
     else if(telemovel!="" && telemovel!=undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
-        alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
+        alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 91234-5678'.");
         return false;
     }
 

--- a/js/form-mask-utils.js
+++ b/js/form-mask-utils.js
@@ -4,17 +4,7 @@ function applyBrazilianMasks() {
     }
     $('#telefone').mask('(00) 0000-0000');
     $('#codigo_postal').mask('99999-999');
-    $('#telemovel').mask('(00) Z 0000-0000', {
-        translation: {
-            'Z': { pattern: /9/ },
-            '0': { pattern: /[0-9]/ }
-        }
-    });
-    $('[name^="autorizacao_telefone"], .autorizacao-telefone').mask('(00) Z 0000-0000', {
-        translation: {
-            'Z': { pattern: /9/ },
-            '0': { pattern: /[0-9]/ }
-        }
-    });
+    $('#telemovel').mask('(00) 90000-0000');
+    $('[name^="autorizacao_telefone"], .autorizacao-telefone').mask('(00) 90000-0000');
 }
 

--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -7,7 +7,7 @@ function telefone_valido(num, locale)
     }
     else if(locale === "BR")
     {
-        const mobile = /^\(\d{2}\) 9 \d{4}-\d{4}$/;
+        const mobile = /^\(\d{2}\) 9\d{4}-\d{4}$/;
         const landline = /^\(\d{2}\) \d{4}-\d{4}$/;
         return mobile.test(num) || landline.test(num);
     }

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -309,7 +309,7 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
 {
     $locale = Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE);
     if($locale == Locale::BRASIL)
-        $msg = "O CEP que introduziu é inválido. Deve ser da forma '99999-999'.";
+        $msg = "O CEP que introduziu é inválido. Deve ser da forma '00000-000'.";
     else
         $msg = "O código postal que introduziu é inválido. Deve ser da forma 'xxxx-xxx Localidade'.";
 
@@ -321,13 +321,13 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
 	  	
 	  	if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve estar no formato '(99) 9999-9999'.</div>");
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve estar no formato '(99) 3333-4444'.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	
 	  	if($telemovel!="" && !DataValidationUtils::validatePhoneNumber($telemovel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de celular que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.</div>");
+                    echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de celular que introduziu é inválido. Deve estar no formato '(99) 91234-5678'.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	

--- a/tests/DataValidationUtilsTest.php
+++ b/tests/DataValidationUtilsTest.php
@@ -10,7 +10,7 @@ class DataValidationUtilsTest extends TestCase
 {
     public function testValidatePhoneNumberValidMobile(): void
     {
-        $this->assertTrue(DataValidationUtils::validatePhoneNumber('(11) 9 1234-5678', Locale::BRASIL));
+        $this->assertTrue(DataValidationUtils::validatePhoneNumber('(11) 91234-5678', Locale::BRASIL));
     }
 
     public function testValidatePhoneNumberValidLandline(): void


### PR DESCRIPTION
## Summary
- update phone regex for Brazil
- tweak BR input masks
- adjust Brazilian placeholders and alerts
- keep validation tests consistent

## Testing
- `php -l core/DataValidationUtils.php`
- `php -l inscricao.php`
- `php -l processarInscricao.php`
- `php -l js/form-validation-utils.js`
- `php -l js/form-mask-utils.js`
- `php -l tests/DataValidationUtilsTest.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a19dba608328a602c239f005c3b9