### PR TITLE
Fix config fetch return checks

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -5441,10 +5441,10 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
             if ($stm->execute())
             {
                 $result = $stm->fetch();
-                if(isset($result))
+                if (is_array($result) && isset($result['valor'])) {
                     return $result['valor'];
-                else
-                    return null;
+                }
+                return null;
             }
             else
                 throw new Exception("Falha ao obter valor de configuração.");


### PR DESCRIPTION
## Summary
- ensure `getConfigValue` verifies the fetch result is an array before using it

## Testing
- `php -l core/PdoDatabaseManager.php`
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6882a7a09ae48328b81f5cf95de0cfae