### PR TITLE
Fix default values for payment service configs

### DIFF
--- a/core/PaymentVerificationService.php
+++ b/core/PaymentVerificationService.php
@@ -17,8 +17,8 @@ class PaymentVerificationService
 
     public function __construct(?string $endpoint = null, ?string $token = null, ?int $timeout = null)
     {
-        $this->endpoint = $endpoint ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PAYMENT_PROVIDER_URL);
-        $this->token     = $token ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PAYMENT_PROVIDER_TOKEN);
+        $this->endpoint = ($endpoint ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PAYMENT_PROVIDER_URL)) ?? '';
+        $this->token     = ($token ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PAYMENT_PROVIDER_TOKEN)) ?? '';
         if ($timeout === null)
             $timeout = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PAYMENT_PROVIDER_TIMEOUT);
         $this->timeout   = $timeout ?? 10;

--- a/core/PixPaymentVerificationService.php
+++ b/core/PixPaymentVerificationService.php
@@ -16,8 +16,8 @@ class PixPaymentVerificationService
 
     public function __construct(?string $endpoint = null, ?string $token = null, ?int $timeout = null)
     {
-        $this->endpoint = $endpoint ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_URL);
-        $this->token     = $token ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_TOKEN);
+        $this->endpoint = ($endpoint ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_URL)) ?? '';
+        $this->token     = ($token ?? Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_TOKEN)) ?? '';
         if ($timeout === null)
             $timeout = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_API_TIMEOUT);
         $this->timeout   = $timeout ?? 10;


### PR DESCRIPTION
## Summary
- ensure provider URL/token fallback to empty string in PaymentVerificationService
- apply same behavior in PixPaymentVerificationService

## Testing
- `php -l core/PixPaymentVerificationService.php`
- `php -l core/PaymentVerificationService.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a7a3479c83288d3c631b380d9ef6