### PR TITLE
Rename duplicate class PaymentVerificationService

### DIFF
--- a/core/PaymentVerificationService.php
+++ b/core/PaymentVerificationService.php
@@ -8,7 +8,7 @@ use catechesis\Configurator;
  * Service to verify Pix payments for an enrolment using an external API.
  * The API is expected to return a JSON payload with fields 'paid' and 'amount'.
  */
-class PixPaymentVerificationService
+class PaymentVerificationService
 {
     private string $endpoint;
     private string $token;


### PR DESCRIPTION
## Summary
- rename `PixPaymentVerificationService` class to `PaymentVerificationService`

## Testing
- `php -l core/PaymentVerificationService.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b8435d3c8328834c6371fa3b444a