### PR TITLE
Fix missing namespace imports in brazilian masks include

### DIFF
--- a/includes/brazilian_masks.php
+++ b/includes/brazilian_masks.php
@@ -1,4 +1,8 @@
 <?php
+
+// Import classes used to check the current locale
+use catechesis\Configurator;
+use core\domain\Locale;
 // Include jQuery mask plugin and apply default Brazilian input masks when locale is BR
 
 // Optionally specify $maskPathPrefix before including this file to adjust the


### PR DESCRIPTION
## Summary
- add missing `use` statements so that `Configurator` and `Locale` resolve correctly when brazilian mask helper is included

## Testing
- `php -l includes/brazilian_masks.php`
- (tests skipped: phpunit not installed)

------
https://chatgpt.com/codex/tasks/task_e_6882b6eef300832886cfb89bd3aa46e3