### PR TITLE
Fix missing dependencies for Brazilian masks

### DIFF
--- a/criarUtilizador.php
+++ b/criarUtilizador.php
@@ -7,11 +7,15 @@ require_once(__DIR__ . '/core/Utils.php');
 require_once(__DIR__ . "/core/PdoDatabaseManager.php");
 require_once(__DIR__ . "/gui/widgets/WidgetManager.php");
 require_once(__DIR__ . '/gui/widgets/Navbar/MainNavbar.php');
+require_once(__DIR__ . '/core/Configurator.php');
+require_once(__DIR__ . '/core/domain/Locale.php');
 
 use catechesis\Authenticator;
 use catechesis\PdoDatabaseManager;
 use catechesis\gui\WidgetManager;
 use catechesis\gui\MainNavbar;
+use catechesis\Configurator;
+use core\domain\Locale;
 use catechesis\gui\MainNavbar\MENU_OPTION;
 
 


### PR DESCRIPTION
## Summary
- include Configurator and Locale requirements in `criarUtilizador.php`
- import their namespaces

## Testing
- `phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6882c999505c8328afa7f4ff007a2e74