### PR TITLE
Add explicit Configurator and Locale includes

### DIFF
--- a/includes/brazilian_masks.php
+++ b/includes/brazilian_masks.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/../core/Configurator.php';
+require_once __DIR__ . '/../core/domain/Locale.php';
 
 // Import classes used to check the current locale
 use catechesis\Configurator;


### PR DESCRIPTION
## Summary
- ensure `includes/brazilian_masks.php` loads Configurator and Locale classes directly

## Testing
- `php -l includes/brazilian_masks.php`

------
https://chatgpt.com/codex/tasks/task_e_6882d810a6748328919872c26e346b60