### PR TITLE
Allow optional amount in Pix QR payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Brazilian donors may contribute using Pix. Configure the following keys in the *
 - `PIX_API_TOKEN` – token for the Pix API
 - `PIX_API_TIMEOUT` – timeout in seconds when calling the API
 
-Call `PixQRCode::generatePixQRCode($amount)` to generate the QR image for the desired amount. When used for enrollments this amount usually corresponds to `ENROLLMENT_PAYMENT_AMOUNT` (default R$100).
+Call `PixQRCode::generatePixQRCode()` with an optional `$amount` to generate the QR image. When an amount is provided it is included as tag `54` in the payload. When omitted the value is not embedded. For enrollments the amount usually corresponds to `ENROLLMENT_PAYMENT_AMOUNT` (default R$100).
 
 Payment confirmation can optionally be automated with `PixPaymentVerificationService`, which expects the provider endpoint, token and timeout to be set via `PIX_PROVIDER_URL`, `PIX_PROVIDER_TOKEN` and `PIX_PROVIDER_TIMEOUT`.
 

--- a/core/PixQRCode.php
+++ b/core/PixQRCode.php
@@ -29,7 +29,7 @@ class PixQRCode{
         return strtoupper(sprintf('%04X', $crc));
     }
 
-    public static function buildPayload(string $key, string $merchantName, string $merchantCity, string $txid, float $amount, string $description = ''): string{
+    public static function buildPayload(string $key, string $merchantName, string $merchantCity, string $txid, ?float $amount, string $description = ''): string{
         $payload  = self::tlv('00', '01');
         $payload .= self::tlv('01', '12');
 
@@ -41,7 +41,9 @@ class PixQRCode{
         $payload .= self::tlv('26', $mai);
         $payload .= self::tlv('52', '0000');
         $payload .= self::tlv('53', '986');
-        $payload .= self::tlv('54', number_format($amount, 2, '.', ''));
+        if($amount !== null){
+            $payload .= self::tlv('54', number_format($amount, 2, '.', ''));
+        }
         $payload .= self::tlv('58', 'BR');
         $payload .= self::tlv('59', substr($merchantName, 0, 25));
         $payload .= self::tlv('60', substr($merchantCity, 0, 15));
@@ -51,7 +53,7 @@ class PixQRCode{
         return $payload;
     }
 
-    public static function generatePixQRCode(float $amount): string{
+    public static function generatePixQRCode(?float $amount = null): string{
         $key  = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_KEY);
         $name = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_NAME);
         $city = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_CITY);

--- a/tests/PixQRCodeTest.php
+++ b/tests/PixQRCodeTest.php
@@ -1,0 +1,21 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use catechesis\PixQRCode;
+
+require_once __DIR__ . '/../core/PixQRCode.php';
+
+class PixQRCodeTest extends TestCase
+{
+    public function testPayloadWithoutAmountOmitsTag54(): void
+    {
+        $payload = PixQRCode::buildPayload('key','Merchant','City','123', null, '');
+        $this->assertStringNotContainsString('54', substr($payload, 0, strpos($payload, '6304')));
+    }
+
+    public function testPayloadWithAmountIncludesTag54(): void
+    {
+        $payload = PixQRCode::buildPayload('key','Merchant','City','123', 10.50, '');
+        $this->assertStringContainsString('54', $payload);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- make Pix QR amount optional in core library
- document optional amount in README
- test omission of tag 54 when amount is null

## Testing
- `php -l core/PixQRCode.php`
- `php -l tests/PixQRCodeTest.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887bb3adf0883289f357d69b4bfc6be