### PR TITLE
Show Pix payload when enrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Brazilian donors may contribute using Pix. Configure the following keys in the *
 - `PIX_API_TOKEN` – token for the Pix API
 - `PIX_API_TIMEOUT` – timeout in seconds when calling the API
 
-Call `PixQRCode::generatePixQRCode($amount)` to generate the QR image for the desired amount. When used for enrollments this amount usually corresponds to `ENROLLMENT_PAYMENT_AMOUNT` (default R$100).
+Call `PixQRCode::generatePixQRCode($amount)` to generate the QR image for the desired amount. The `$amount` parameter is optional; pass `null` to omit the value from the generated code. When used for enrollments this amount usually corresponds to `ENROLLMENT_PAYMENT_AMOUNT` (default R$100).
 
 Payment confirmation can optionally be automated with `PixPaymentVerificationService`, which expects the provider endpoint, token and timeout to be set via `PIX_PROVIDER_URL`, `PIX_PROVIDER_TOKEN` and `PIX_PROVIDER_TIMEOUT`.
 

--- a/core/PixQRCode.php
+++ b/core/PixQRCode.php
@@ -29,7 +29,7 @@ class PixQRCode{
         return strtoupper(sprintf('%04X', $crc));
     }
 
-    public static function buildPayload(string $key, string $merchantName, string $merchantCity, string $txid, float $amount, string $description = ''): string{
+    public static function buildPayload(string $key, string $merchantName, string $merchantCity, string $txid, ?float $amount, string $description = ''): string{
         $payload  = self::tlv('00', '01');
         $payload .= self::tlv('01', '12');
 
@@ -41,7 +41,9 @@ class PixQRCode{
         $payload .= self::tlv('26', $mai);
         $payload .= self::tlv('52', '0000');
         $payload .= self::tlv('53', '986');
-        $payload .= self::tlv('54', number_format($amount, 2, '.', ''));
+        if($amount !== null){
+            $payload .= self::tlv('54', number_format($amount, 2, '.', ''));
+        }
         $payload .= self::tlv('58', 'BR');
         $payload .= self::tlv('59', substr($merchantName, 0, 25));
         $payload .= self::tlv('60', substr($merchantCity, 0, 15));
@@ -51,7 +53,7 @@ class PixQRCode{
         return $payload;
     }
 
-    public static function generatePixQRCode(float $amount): string{
+    public static function generatePixQRCode(?float $amount): string{
         $key  = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_KEY);
         $name = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_NAME);
         $city = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_CITY);
@@ -77,6 +79,20 @@ class PixQRCode{
         QrCode::png($payload, null, 300, 0);
         $data = ob_get_clean();
         return 'data:image/png;base64,'.base64_encode($data);
+    }
+
+    public static function generatePixPayload(?float $amount): string{
+        $key  = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_KEY);
+        $name = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_NAME);
+        $city = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_CITY);
+        $desc = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_DESCRIPTION) ?? '';
+        $txid = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_TXID) ?? '***';
+
+        if(!$key || !$name || !$city){
+            throw new Exception('Pix configuration incomplete');
+        }
+
+        return self::buildPayload($key, $name, $city, $txid, $amount, $desc);
     }
 }
 ?>

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -509,15 +509,21 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
                     }
                     if ($pixAvailable) {
                         try {
-                            $pixImg = PixQRCode::generatePixQRCode(Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT));
+                            $pixImg = PixQRCode::generatePixQRCode(null);
+                            $pixPayload = PixQRCode::generatePixPayload(null);
                         } catch (Exception $e) {
                             $pixImg = null;
+                            $pixPayload = null;
                         }
                         if ($pixImg) {
                             ?>
                             <div style="margin-top:20px;text-align:center;">
                                 <p>Para efetuar o seu donativo via <strong>Pix</strong>, utilize o QR code abaixo:</p>
                                 <img src="<?= $pixImg ?>" alt="Pix QR Code" />
+                                <?php if ($pixPayload) { ?>
+                                    <p style="margin-top:10px;word-break:break-all;">Pix copia e cola:</p>
+                                    <pre style="white-space: pre-wrap; word-wrap: break-word;"><?= $pixPayload ?></pre>
+                                <?php } ?>
                             </div>
                             <?php
                         }

--- a/publico/doRenovarMatricula.php
+++ b/publico/doRenovarMatricula.php
@@ -196,15 +196,23 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
                 }
                 if ($pixAvailable) {
                     try {
-                        $pixImg = PixQRCode::generatePixQRCode(Configurator::getConfigurationValueOrDefault(Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT));
+                        $pixImg = PixQRCode::generatePixQRCode(null);
+                        $pixPayload = PixQRCode::generatePixPayload(null);
                     } catch (Exception $e) {
                         $pixImg = null;
+                        $pixPayload = null;
                     }
                     if ($pixImg) {
                         ?>
                         <div style="margin-top:20px;text-align:center;">
                             <p>Para efetuar o seu donativo via <strong>Pix</strong>, utilize o QR code abaixo:</p>
                             <img src="<?= $pixImg ?>" alt="Pix QR Code" />
+                            <?php if ($pixPayload) { ?>
+                                <p style="margin-top:10px;word-break:break-all;">Pix copia e cola:</p>
+                                <pre style="white-space: pre-wrap; word-wrap: break-word;">
+                                    <?= $pixPayload ?>
+                                </pre>
+                            <?php } ?>
                         </div>
                         <?php
                     }


### PR DESCRIPTION
## Summary
- allow `PixQRCode::generatePixQRCode()` to accept `null` amounts and expose a new `generatePixPayload()` helper
- document optional argument in README
- display Pix QR and "copia e cola" payload during enrollment and renewal

## Testing
- `php -l publico/doInscrever.php`
- `php -l publico/doRenovarMatricula.php`
- `php -l core/PixQRCode.php`
- `phpunit --configuration phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6887bb3c3d3c83288df4e421f78839a1