### PR TITLE
Fix brazilian masks Configurator reference

### DIFF
--- a/includes/brazilian_masks.php
+++ b/includes/brazilian_masks.php
@@ -1,6 +1,13 @@
 <?php
 // Include jQuery mask plugin and apply default Brazilian input masks when locale is BR
 
+// Load dependencies in case they weren't required by the including script
+require_once(__DIR__ . '/../core/Configurator.php');
+require_once(__DIR__ . '/../core/domain/Locale.php');
+
+use catechesis\Configurator;
+use core\domain\Locale;
+
 // Optionally specify $maskPathPrefix before including this file to adjust the
 // relative path of the JS files. Default is an empty string which works for
 // files in the project root.


### PR DESCRIPTION
## Summary
- include dependencies and namespace imports directly in `brazilian_masks.php`
- ensures Configurator and Locale classes exist when the file is included

## Testing
- `php -l includes/brazilian_masks.php`


------
https://chatgpt.com/codex/tasks/task_e_6887b9f999508328a3a275b0f1c25339