### PR TITLE
Update example phone and CEP formats

### DIFF
--- a/mostrarAutorizacoes.php
+++ b/mostrarAutorizacoes.php
@@ -352,7 +352,7 @@ $menu->renderHTML();
                 {
                     echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de "
                         . ((Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'celular' : 'telemóvel')
-                        . " que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.</div>");
+                        . " que introduziu é inválido. Deve estar no formato '(99) 91234-5678'.</div>");
                     $inputs_invalidos = true;
                 }
 
@@ -780,7 +780,7 @@ function valida_dados_familiar()
     var telemovel = document.getElementById('telemovel').value;
     if(!telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
     {
-        alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
+        alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 91234-5678'.");
         return false;
     }
     return true;

--- a/mostrarPedidoInscricao.php
+++ b/mostrarPedidoInscricao.php
@@ -798,7 +798,7 @@ function validar()
         
         if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'O CEP que introduziu é inválido. Deve ser da forma \u002799999-999\u0027.' : 'O código postal que introduziu é inválido. Deve ser da forma \u0027xxxx-xxx Localidade\u0027.' ?>");
+                alert("<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'O CEP que introduziu é inválido. Deve ser da forma \u002700000-000\u0027.' : 'O código postal que introduziu é inválido. Deve ser da forma \u0027xxxx-xxx Localidade\u0027.' ?>");
                 return false;
         }
                 
@@ -811,12 +811,12 @@ function validar()
         }
         else if(telefone!=="" && telefone!==undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O número de telefone que introduziu é inválido. Deve estar no formato '(99) 9999-9999'.");
+                alert("O número de telefone que introduziu é inválido. Deve estar no formato '(99) 3333-4444'.");
 		return false; 
         }
         else if(telemovel!=="" && telemovel!==undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
+                alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 91234-5678'.");
                 return false;
         }
         

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -324,7 +324,7 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
 {
     $locale = Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE);
     if($locale == Locale::BRASIL)
-        $msg = "O CEP que introduziu é inválido. Deve ser da forma '99999-999'.";
+        $msg = "O CEP que introduziu é inválido. Deve ser da forma '00000-000'.";
     else
         $msg = "O código postal que introduziu é inválido. Deve ser da forma 'xxxx-xxx Localidade'.";
 
@@ -336,13 +336,13 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
 	  	
 	  	if($telefone!="" && !DataValidationUtils::validatePhoneNumber($telefone, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve estar no formato '(99) 9999-9999'.</div>");
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de telefone que introduziu é inválido. Deve estar no formato '(99) 3333-4444'.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	
 	  	if($telemovel!="" && !DataValidationUtils::validatePhoneNumber($telemovel, Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE)))
 	  	{
-	  		echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de celular que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.</div>");
+                        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> O número de celular que introduziu é inválido. Deve estar no formato '(99) 91234-5678'.</div>");
 	  		$inputs_invalidos = true;	  	
 	  	}
 	  	

--- a/publico/inscrever.php
+++ b/publico/inscrever.php
@@ -783,7 +783,7 @@ function validar()
         
         if(!codigo_postal_valido(cod_postal, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'O CEP que introduziu é inválido. Deve ser da forma \u002799999-999\u0027.' : 'O código postal que introduziu é inválido. Deve ser da forma \u0027xxxx-xxx Localidade\u0027.' ?>");
+                alert("<?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL) ? 'O CEP que introduziu é inválido. Deve ser da forma \u002700000-000\u0027.' : 'O código postal que introduziu é inválido. Deve ser da forma \u0027xxxx-xxx Localidade\u0027.' ?>");
                 return false;
         }
                 
@@ -796,12 +796,12 @@ function validar()
         }
         else if(telefone!=="" && telefone!==undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O número de telefone que introduziu é inválido. Deve estar no formato '(99) 9999-9999'.");
+                alert("O número de telefone que introduziu é inválido. Deve estar no formato '(99) 3333-4444'.");
 		return false; 
         }
         else if(telemovel!=="" && telemovel!==undefined && !telefone_valido(telemovel, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-                alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 9 9999-9999'.");
+                alert("O número de <?= (Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) == Locale::BRASIL)?'celular':'telemóvel' ?> que introduziu é inválido. Deve estar no formato '(99) 91234-5678'.");
                 return false;
         }
         

--- a/publico/renovarMatricula.php
+++ b/publico/renovarMatricula.php
@@ -238,7 +238,7 @@ $(function(){
 
         if(telefone!=="" && telefone!==undefined && !telefone_valido(telefone, '<?= Configurator::getConfigurationValueOrDefault(Configurator::KEY_LOCALIZATION_CODE) ?>'))
         {
-            alert("O número de telefone que introduziu é inválido. Deve estar no formato '(99) 9999-9999'.");
+            alert("O número de telefone que introduziu é inválido. Deve estar no formato '(99) 3333-4444'.");
             return false;
         }
         if(email!=="" && email!==undefined && !email_valido(email))


### PR DESCRIPTION
## Summary
- adjust error messages to showcase proper phone and CEP formats

## Testing
- `php -l publico/doInscrever.php`
- `php -l publico/renovarMatricula.php`
- `php -l publico/inscrever.php`
- `php -l mostrarPedidoInscricao.php`
- `php -l mostrarAutorizacoes.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887c54cf63c8328bc7df21bf6cc3816