### PR TITLE
Improve phone validation handling

### DIFF
--- a/core/DataValidationUtils.php
+++ b/core/DataValidationUtils.php
@@ -49,23 +49,27 @@ class DataValidationUtils
             $antipattern2 = "111111111";
             $antipattern3 = "123456789";
             $match = preg_match($pattern, $tel);
+            $telCheck = preg_replace('/\D/', '', $tel);
         }
         else if($locale==Locale::BRASIL)
         {
-            $mobilePattern = '/^\(\d{2}\) 9\d{4}-\d{4}$/';
-            $landlinePattern = '/^\(\d{2}\) \d{4}-\d{4}$/';
-            $antipattern1 = "0000-0000";
-            $antipattern2 = "1111-1111";
-            $antipattern3 = "1234-5678";
-            $match = preg_match($mobilePattern, $tel) || preg_match($landlinePattern, $tel);
+            $telDigits = preg_replace('/\D/', '', $tel);
+            $mobilePattern = '/^\d{2}9\d{8}$/';
+            $landlinePattern = '/^\d{2}\d{8}$/';
+            $antipattern1 = "00000000";
+            $antipattern2 = "11111111";
+            $antipattern3 = "12345678";
+            $match = preg_match($mobilePattern, $telDigits) || preg_match($landlinePattern, $telDigits);
+            $telCheck = $telDigits;
         }
         else
         {
             $match = false;
+            $telCheck = $tel;
         }
 
         return $match && (!$checkAntiPatterns ||
-                (strpos($tel, $antipattern1)===false && strpos($tel, $antipattern2)===false && strpos($tel, $antipattern3)===false));
+                (strpos($telCheck, $antipattern1)===false && strpos($telCheck, $antipattern2)===false && strpos($telCheck, $antipattern3)===false));
     }
 
     /**

--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -7,8 +7,9 @@ function telefone_valido(num, locale)
     }
     else if(locale === "BR")
     {
-        const mobile = /^\(\d{2}\) 9\d{4}-\d{4}$/;
-        const landline = /^\(\d{2}\) \d{4}-\d{4}$/;
+        num = num.replace(/\D/g, '');
+        const mobile = /^\d{2}9\d{8}$/;
+        const landline = /^\d{2}\d{8}$/;
         return mobile.test(num) || landline.test(num);
     }
 

--- a/tests/DataValidationUtilsTest.php
+++ b/tests/DataValidationUtilsTest.php
@@ -8,19 +8,29 @@ require_once __DIR__ . '/../core/domain/Locale.php';
 
 class DataValidationUtilsTest extends TestCase
 {
-    public function testValidatePhoneNumberValidMobile(): void
+    public function testValidatePhoneNumberValidMobileFormatted(): void
     {
         $this->assertTrue(DataValidationUtils::validatePhoneNumber('(11) 91234-5678', Locale::BRASIL));
     }
 
-    public function testValidatePhoneNumberValidLandline(): void
+    public function testValidatePhoneNumberValidMobileDigits(): void
+    {
+        $this->assertTrue(DataValidationUtils::validatePhoneNumber('11912345678', Locale::BRASIL));
+    }
+
+    public function testValidatePhoneNumberValidLandlineFormatted(): void
     {
         $this->assertTrue(DataValidationUtils::validatePhoneNumber('(21) 1234-5678', Locale::BRASIL));
     }
 
-    public function testValidatePhoneNumberInvalidMissingHyphen(): void
+    public function testValidatePhoneNumberValidLandlineDigits(): void
     {
-        $this->assertFalse(DataValidationUtils::validatePhoneNumber('(21) 12345678', Locale::BRASIL));
+        $this->assertTrue(DataValidationUtils::validatePhoneNumber('2112345678', Locale::BRASIL));
+    }
+
+    public function testValidatePhoneNumberValidMissingHyphen(): void
+    {
+        $this->assertTrue(DataValidationUtils::validatePhoneNumber('(21) 12345678', Locale::BRASIL));
     }
 
     public function testValidatePhoneNumberInvalidLength(): void


### PR DESCRIPTION
## Summary
- sanitize phone input before regex checks
- update JS phone validation to strip punctuation
- expand phone validation unit tests for unformatted numbers

## Testing
- `phpunit tests/DataValidationUtilsTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c9e9e12883288196729d6b5265d1