### PR TITLE
Add debug logging in validation helpers

### DIFF
--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -1,18 +1,26 @@
 
 function telefone_valido(num, locale)
 {
+    var digits = num.replace(/\D/g, '');
+    var pattern = null;
+
     if(locale === "PT")
     {
-        return /^(\+\d{1,}[-\s]{0,1})?\d{9}$/.test(num);
+        pattern = /^(\+\d{1,}[-\s]{0,1})?\d{9}$/;
+        if(typeof window !== 'undefined' && window.console)
+            console.log('telefone_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
+        return pattern.test(num);
     }
     else if(locale === "BR")
     {
-        num = num.replace(/\D/g, '');
-        const mobile = /^\d{2}9\d{8}$/;
-        const landline = /^\d{2}\d{8}$/;
-        return mobile.test(num) || landline.test(num);
+        pattern = /^\d{2}9?\d{8}$/;
+        if(typeof window !== 'undefined' && window.console)
+            console.log('telefone_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
+        return pattern.test(digits);
     }
 
+    if(typeof window !== 'undefined' && window.console)
+        console.log('telefone_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
     return false;
 }
 
@@ -24,12 +32,16 @@ function email_valido(email)
 
 function codigo_postal_valido(codigo, locale)
 {
+    var digits = codigo.replace(/\D/g, '');
     var pattern = "";
     if(locale==="PT")
         pattern = /^[0-9]{4}\-[0-9]{3}\s\S+/;
     else if(locale==="BR")
         // Brazilian zip code without locality
         pattern = /^[0-9]{5}\-[0-9]{3}$/;
+
+    if(typeof window !== 'undefined' && window.console)
+        console.log('codigo_postal_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
 
     return (pattern.test(codigo));
 }


### PR DESCRIPTION
## Summary
- log the regex used for telefone and postal code validation along with sanitized digits
- guard these logs behind a check for window.console

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887d306105c832899f747e6868355bb