### PR TITLE
Normalize locale input in JS validation

### DIFF
--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -1,18 +1,25 @@
 
 function telefone_valido(num, locale)
 {
+    locale = (locale || '').trim().toUpperCase();
+    console.log('telefone_valido locale:', locale);
+
     if(locale === "PT")
     {
-        return /^(\+\d{1,}[-\s]{0,1})?\d{9}$/.test(num);
+        const pattern = /^(\+\d{1,}[-\s]{0,1})?\d{9}$/;
+        console.log('telefone_valido regex:', pattern);
+        return pattern.test(num);
     }
     else if(locale === "BR")
     {
         num = num.replace(/\D/g, '');
         const mobile = /^\d{2}9\d{8}$/;
         const landline = /^\d{2}\d{8}$/;
+        console.log('telefone_valido regex:', mobile, 'or', landline);
         return mobile.test(num) || landline.test(num);
     }
 
+    console.log('telefone_valido regex: none');
     return false;
 }
 
@@ -24,6 +31,8 @@ function email_valido(email)
 
 function codigo_postal_valido(codigo, locale)
 {
+    locale = (locale || '').trim().toUpperCase();
+    console.log('codigo_postal_valido locale:', locale);
     var pattern = "";
     if(locale==="PT")
         pattern = /^[0-9]{4}\-[0-9]{3}\s\S+/;
@@ -31,6 +40,7 @@ function codigo_postal_valido(codigo, locale)
         // Brazilian zip code without locality
         pattern = /^[0-9]{5}\-[0-9]{3}$/;
 
+    console.log('codigo_postal_valido regex:', pattern);
     return (pattern.test(codigo));
 }
 


### PR DESCRIPTION
## Summary
- normalize locale before validating phone numbers and postal codes
- log normalized locale and regex used

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d2044cd483289eb7acb90b4dd266