### PR TITLE
Add debug logging for validation patterns

### DIFF
--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -1,16 +1,33 @@
 
 function telefone_valido(num, locale)
 {
+    var digits = (num || '').replace(/\D/g, '');
+    var pattern;
+
     if(locale === "PT")
     {
-        return /^(\+\d{1,}[-\s]{0,1})?\d{9}$/.test(num);
+        pattern = /^(\+\d{1,}[-\s]{0,1})?\d{9}$/;
+        if(typeof window !== 'undefined' && window.console)
+            console.log('telefone_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
+        return pattern.test(num);
     }
     else if(locale === "BR")
     {
-        num = num.replace(/\D/g, '');
         const mobile = /^\d{2}9\d{8}$/;
         const landline = /^\d{2}\d{8}$/;
-        return mobile.test(num) || landline.test(num);
+
+        pattern = mobile;
+        var result = mobile.test(digits);
+        if(!result)
+        {
+            pattern = landline;
+            result = landline.test(digits);
+        }
+
+        if(typeof window !== 'undefined' && window.console)
+            console.log('telefone_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
+
+        return result;
     }
 
     return false;
@@ -25,11 +42,15 @@ function email_valido(email)
 function codigo_postal_valido(codigo, locale)
 {
     var pattern = "";
+    var digits = (codigo || '').replace(/\D/g, '');
     if(locale==="PT")
         pattern = /^[0-9]{4}\-[0-9]{3}\s\S+/;
     else if(locale==="BR")
         // Brazilian zip code without locality
         pattern = /^[0-9]{5}\-[0-9]{3}$/;
+
+    if(typeof window !== 'undefined' && window.console)
+        console.log('codigo_postal_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
 
     return (pattern.test(codigo));
 }


### PR DESCRIPTION
## Summary
- log sanitized phone and postal code values with their regex patterns
- guard logs behind `window.console` checks

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d48bac00832882dace6bfa039770