### PR TITLE
Fix Brazilian phone validation

### DIFF
--- a/core/DataValidationUtils.php
+++ b/core/DataValidationUtils.php
@@ -54,12 +54,26 @@ class DataValidationUtils
         else if($locale==Locale::BRASIL)
         {
             $telDigits = preg_replace('/\D/', '', $tel);
-            $mobilePattern = '/^\d{2}9\d{8}$/';
-            $landlinePattern = '/^\d{2}\d{8}$/';
+
+            // Accept either 11 digits for mobiles or 10 digits for landlines.
+            // Mobile numbers must have the third digit equal to 9, while
+            // landlines cannot start with 9 after the DDD.
+            if(strlen($telDigits) === 11 && $telDigits[2] === '9')
+            {
+                $match = true;
+            }
+            else if(strlen($telDigits) === 10 && $telDigits[2] !== '9')
+            {
+                $match = true;
+            }
+            else
+            {
+                $match = false;
+            }
+
             $antipattern1 = "00000000";
             $antipattern2 = "11111111";
             $antipattern3 = "12345678";
-            $match = preg_match($mobilePattern, $telDigits) || preg_match($landlinePattern, $telDigits);
             $telCheck = $telDigits;
         }
         else

--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -12,19 +12,21 @@ function telefone_valido(num, locale)
     }
     else if(locale === "BR")
     {
-        const mobile = /^\d{2}9\d{8}$/;
-        const landline = /^\d{2}\d{8}$/;
-
-        pattern = mobile;
-        var result = mobile.test(digits);
-        if(!result)
+        // Accept either 11 digits for mobiles or 10 digits for landlines.
+        // Mobile numbers must have the third digit equal to 9, while
+        // landlines cannot start with 9 after the DDD.
+        var result = false;
+        if(digits.length === 11 && digits.charAt(2) === '9')
         {
-            pattern = landline;
-            result = landline.test(digits);
+            result = true;
+        }
+        else if(digits.length === 10 && digits.charAt(2) !== '9')
+        {
+            result = true;
         }
 
         if(typeof window !== 'undefined' && window.console)
-            console.log('telefone_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
+            console.log('telefone_valido -> locale:', locale, 'digits:', digits, 'result:', result);
 
         return result;
     }

--- a/tests/DataValidationUtilsTest.php
+++ b/tests/DataValidationUtilsTest.php
@@ -38,6 +38,16 @@ class DataValidationUtilsTest extends TestCase
         $this->assertFalse(DataValidationUtils::validatePhoneNumber('(211) 1234-5678', Locale::BRASIL));
     }
 
+    public function testValidatePhoneNumberInvalidMobileWithoutNine(): void
+    {
+        $this->assertFalse(DataValidationUtils::validatePhoneNumber('(11) 81234-5678', Locale::BRASIL));
+    }
+
+    public function testValidatePhoneNumberInvalidLandlineWithNine(): void
+    {
+        $this->assertFalse(DataValidationUtils::validatePhoneNumber('2191234567', Locale::BRASIL));
+    }
+
     public function testValidateZipCodeValid(): void
     {
         $this->assertTrue(DataValidationUtils::validateZipCode('12345-678', Locale::BRASIL));


### PR DESCRIPTION
## Summary
- handle Brazilian phone numbers without relying on regex
- log JS phone validation result
- cover edge cases in DataValidationUtilsTest

## Testing
- `php -l core/DataValidationUtils.php`
- `vendor/bin/phpunit` *(fails: No such file)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887da1cadd88328aad5f214e45d7670