### PR TITLE
Normalize configuration strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Administrators can select the country used for address and phone formats in
 `LOCALIZATION_CODE` and it accepts the values `PT` (Portugal) and `BR`
 (Brazil).  The choice affects several labels and validation rules across the
 application.
+Any whitespace around this value is ignored by the configurator, so
+`LOCALIZATION_CODE` values are normalized automatically.
 
 If changing the value through the interface is not possible, update it directly
 in the database:

--- a/core/Configurator.php
+++ b/core/Configurator.php
@@ -80,7 +80,7 @@ class ConfigurationObject
 
             case self::TYPE_STRING:
             default:
-                return $value;
+                return trim($value);
         }
     }
 }


### PR DESCRIPTION
## Summary
- trim string values when reading from configuration
- document localization code normalization

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*
- `vendor/bin/phpunit -c phpunit.xml` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6887dec69ac08328a60eef5d013b2b68