### PR TITLE
Fix PT phone regex

### DIFF
--- a/js/form-validation-utils.js
+++ b/js/form-validation-utils.js
@@ -8,7 +8,7 @@ function telefone_valido(num, locale)
         pattern = /^(\+\d{1,}[-\s]{0,1})?\d{9}$/;
         if(typeof window !== 'undefined' && window.console)
             console.log('telefone_valido -> locale:', locale, 'digits:', digits, 'pattern:', pattern);
-        return pattern.test(num);
+        return pattern.test(digits);
     }
     else if(locale === "BR")
     {


### PR DESCRIPTION
## Summary
- ensure Portuguese phone validation runs regex on sanitized digits

## Testing
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('./js/form-validation-utils.js','utf8');
vm.runInThisContext(code);
console.log(telefone_valido('(21) 234-5678', 'PT'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6887ea491e6c83288f8a509becad9cde