### PR TITLE
Add PHPUnit dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ The `updater/` directory contains a web based assistant that downloads new versi
 
 Whenever an update includes database migrations, the assistant will automatically run the provided SQL scripts. If you update files manually, execute the scripts from `updater/sql_scripts` using your database client.
 
+## Running tests
+
+After installing the Composer dependencies you can execute the test suite using PHPUnit:
+
+```bash
+vendor/bin/phpunit
+```
+

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "endroid/qr-code": "^5.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
     }
 }


### PR DESCRIPTION
## Summary
- add phpunit/phpunit as a dev requirement
- document running `vendor/bin/phpunit`

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6887ea4a5be083289ea028ff2a5033f2