### PR TITLE
Wrap settings POST handler in request check

### DIFF
--- a/configuracoes.php
+++ b/configuracoes.php
@@ -176,8 +176,11 @@ $menu->renderHTML();
                         <?php
 
                         // Handle POSTs to change settings
-                        foreach($settingsPanels as $panel)
-                            $panel->handlePost();
+                        if($_SERVER['REQUEST_METHOD'] === 'POST')
+                        {
+                            foreach($settingsPanels as $panel)
+                                $panel->handlePost();
+                        }
 
                         // Render settings panels
                         foreach($settingsPanels as $panel)


### PR DESCRIPTION
## Summary
- only trigger settings panels' `handlePost` when request is POST

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68883032caf08328aa13350652cf7e7f