### PR TITLE
Fix sidebar target check in configuracoes.php

### DIFF
--- a/configuracoes.php
+++ b/configuracoes.php
@@ -214,9 +214,9 @@ $pageUI->renderJS(); // Render the widgets' JS code
                 link.addEventListener('click', function (ev) {
                     var href = link.getAttribute('href');
                     if (href && href.startsWith('#')) {
-                        ev.preventDefault();
                         var target = document.querySelector(href);
                         if (target) {
+                            ev.preventDefault();
                             history.pushState(null, '', href);
                             target.scrollIntoView({behavior: 'smooth'});
                         }


### PR DESCRIPTION
## Summary
- only prevent default navigation if the sidebar anchor has a matching panel

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688835e2fdbc83289f558852b5778bbb