### PR TITLE
Update payment verification tests to stub curl

### DIFF
--- a/tests/PaymentVerificationServiceTest.php
+++ b/tests/PaymentVerificationServiceTest.php
@@ -1,7 +1,22 @@
 <?php
 namespace catechesis {
-    function file_get_contents($filename, $use_include_path = false, $context = null) {
-        return \PaymentVerificationServiceTest::$mockResponse;
+    function curl_init($url = null) {
+        return \curl_init($url);
+    }
+
+    function curl_exec($ch) {
+        return \PaymentVerificationServiceTest::$mockResponse['exec'];
+    }
+
+    function curl_getinfo($ch, $option) {
+        if ($option === CURLINFO_HTTP_CODE) {
+            return \PaymentVerificationServiceTest::$mockResponse['status'];
+        }
+        return null;
+    }
+
+    function curl_close($ch) {
+        \curl_close($ch);
     }
 }
 
@@ -13,37 +28,37 @@ namespace {
 
     class PaymentVerificationServiceTest extends TestCase
     {
-        public static $mockResponse;
+        public static array $mockResponse;
 
     public function testVerifyPaymentSuccess(): void
     {
-        self::$mockResponse = json_encode(['paid' => true, 'amount' => 20]);
-        $service = new PaymentVerificationService('http://example', 'token');
+        self::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 20]), 'status' => 200];
+        $service = new PaymentVerificationService('http://example', 'token', 10);
         $this->assertTrue($service->verifyPayment(1, '123', 10));
     }
 
     public function testVerifyPaymentInsufficientAmount(): void
     {
-        self::$mockResponse = json_encode(['paid' => true, 'amount' => 5]);
-        $service = new PaymentVerificationService('http://example', 'token');
+        self::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 5]), 'status' => 200];
+        $service = new PaymentVerificationService('http://example', 'token', 10);
         $this->assertFalse($service->verifyPayment(1, '123', 10));
     }
 
     public function testVerifyPaymentFailure(): void
     {
-        self::$mockResponse = false;
-        $service = new PaymentVerificationService('http://example', 'token');
+        self::$mockResponse = ['exec' => false, 'status' => 0];
+        $service = new PaymentVerificationService('http://example', 'token', 10);
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Failed to connect to payment provider.');
+        $this->expectExceptionMessage('Failed to connect to Pix provider.');
         $service->verifyPayment(1, '123', 10);
     }
 
     public function testVerifyPaymentInvalidResponse(): void
     {
-        self::$mockResponse = 'invalid';
-        $service = new PaymentVerificationService('http://example', 'token');
+        self::$mockResponse = ['exec' => 'invalid', 'status' => 200];
+        $service = new PaymentVerificationService('http://example', 'token', 10);
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Invalid response from payment provider.');
+        $this->expectExceptionMessage('Invalid response from Pix provider.');
         $service->verifyPayment(1, '123', 10);
     }
     }


### PR DESCRIPTION
## Summary
- stub curl functions at the `catechesis` namespace in PaymentVerificationService tests
- update expectations for new Pix provider messages
- provide similar stubs for PixPaymentVerificationService tests

## Testing
- `vendor/bin/phpunit tests/PaymentVerificationServiceTest.php`
- `vendor/bin/phpunit tests/PixPaymentVerificationServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68883e21e8d4832882180bffa52764fa