### PR TITLE
Fix sidebar navigation in settings panel

### DIFF
--- a/configuracoes.php
+++ b/configuracoes.php
@@ -244,9 +244,13 @@ if (sidebar) {
         (function (link) {
             link.addEventListener('click', function (ev) {
                 var href = link.getAttribute('href');
-                if (href && href.startsWith('#')) {
+                if (href && href.charAt(0) === '#') {
                     ev.preventDefault();
-                    history.pushState(null, '', href);
+                    if (history.pushState) {
+                        history.pushState(null, '', href);
+                    } else {
+                        window.location.hash = href;
+                    }
                     showPanel(href);
                 }
             });


### PR DESCRIPTION
## Summary
- ensure sidebar links work on older browsers

## Testing
- `php -l configuracoes.php`
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: Cannot redeclare function catechesis\curl_init)*

------
https://chatgpt.com/codex/tasks/task_e_6888cf3778848328908082c1831bf011