### PR TITLE
Fix curl stub redeclaration

### DIFF
--- a/tests/CurlStubs.php
+++ b/tests/CurlStubs.php
@@ -1,0 +1,30 @@
+<?php
+namespace catechesis;
+
+class CurlStubs
+{
+    public static array $mockResponse = ['exec' => false, 'status' => 0];
+}
+
+function curl_init($url = null)
+{
+    return \curl_init($url);
+}
+
+function curl_exec($ch)
+{
+    return CurlStubs::$mockResponse['exec'];
+}
+
+function curl_getinfo($ch, $option)
+{
+    if ($option === CURLINFO_HTTP_CODE) {
+        return CurlStubs::$mockResponse['status'];
+    }
+    return null;
+}
+
+function curl_close($ch)
+{
+    \curl_close($ch);
+}

--- a/tests/PaymentVerificationServiceTest.php
+++ b/tests/PaymentVerificationServiceTest.php
@@ -1,23 +1,6 @@
 <?php
 namespace catechesis {
-    function curl_init($url = null) {
-        return \curl_init($url);
-    }
-
-    function curl_exec($ch) {
-        return \PaymentVerificationServiceTest::$mockResponse['exec'];
-    }
-
-    function curl_getinfo($ch, $option) {
-        if ($option === CURLINFO_HTTP_CODE) {
-            return \PaymentVerificationServiceTest::$mockResponse['status'];
-        }
-        return null;
-    }
-
-    function curl_close($ch) {
-        \curl_close($ch);
-    }
+    // Curl functions are stubbed globally via CurlStubs.php
 }
 
 namespace {
@@ -28,25 +11,24 @@ namespace {
 
     class PaymentVerificationServiceTest extends TestCase
     {
-        public static array $mockResponse;
 
     public function testVerifyPaymentSuccess(): void
     {
-        self::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 20]), 'status' => 200];
+        \catechesis\CurlStubs::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 20]), 'status' => 200];
         $service = new PaymentVerificationService('http://example', 'token', 10);
         $this->assertTrue($service->verifyPayment(1, '123', 10));
     }
 
     public function testVerifyPaymentInsufficientAmount(): void
     {
-        self::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 5]), 'status' => 200];
+        \catechesis\CurlStubs::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 5]), 'status' => 200];
         $service = new PaymentVerificationService('http://example', 'token', 10);
         $this->assertFalse($service->verifyPayment(1, '123', 10));
     }
 
     public function testVerifyPaymentFailure(): void
     {
-        self::$mockResponse = ['exec' => false, 'status' => 0];
+        \catechesis\CurlStubs::$mockResponse = ['exec' => false, 'status' => 0];
         $service = new PaymentVerificationService('http://example', 'token', 10);
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to connect to Pix provider.');
@@ -55,7 +37,7 @@ namespace {
 
     public function testVerifyPaymentInvalidResponse(): void
     {
-        self::$mockResponse = ['exec' => 'invalid', 'status' => 200];
+        \catechesis\CurlStubs::$mockResponse = ['exec' => 'invalid', 'status' => 200];
         $service = new PaymentVerificationService('http://example', 'token', 10);
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid response from Pix provider.');

--- a/tests/PixPaymentVerificationServiceTest.php
+++ b/tests/PixPaymentVerificationServiceTest.php
@@ -1,23 +1,6 @@
 <?php
 namespace catechesis {
-    function curl_init($url = null) {
-        return \curl_init($url);
-    }
-
-    function curl_exec($ch) {
-        return \PixPaymentVerificationServiceTest::$mockResponse['exec'];
-    }
-
-    function curl_getinfo($ch, $option) {
-        if ($option === CURLINFO_HTTP_CODE) {
-            return \PixPaymentVerificationServiceTest::$mockResponse['status'];
-        }
-        return null;
-    }
-
-    function curl_close($ch) {
-        \curl_close($ch);
-    }
+    // Curl functions are stubbed globally via CurlStubs.php
 }
 
 namespace {
@@ -28,25 +11,24 @@ namespace {
 
     class PixPaymentVerificationServiceTest extends TestCase
     {
-    public static array $mockResponse;
 
     public function testVerifyPaymentSuccess(): void
     {
-        self::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 20]), 'status' => 200];
+        \catechesis\CurlStubs::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 20]), 'status' => 200];
         $service = new PixPaymentVerificationService('http://example', 'token', 10);
         $this->assertTrue($service->verifyPayment(1, 'key', 10));
     }
 
     public function testVerifyPaymentInsufficientAmount(): void
     {
-        self::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 5]), 'status' => 200];
+        \catechesis\CurlStubs::$mockResponse = ['exec' => json_encode(['paid' => true, 'amount' => 5]), 'status' => 200];
         $service = new PixPaymentVerificationService('http://example', 'token', 10);
         $this->assertFalse($service->verifyPayment(1, 'key', 10));
     }
 
     public function testVerifyPaymentFailure(): void
     {
-        self::$mockResponse = ['exec' => false, 'status' => 0];
+        \catechesis\CurlStubs::$mockResponse = ['exec' => false, 'status' => 0];
         $service = new PixPaymentVerificationService('http://example', 'token', 10);
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to connect to Pix provider.');
@@ -55,7 +37,7 @@ namespace {
 
     public function testVerifyPaymentInvalidResponse(): void
     {
-        self::$mockResponse = ['exec' => 'invalid', 'status' => 200];
+        \catechesis\CurlStubs::$mockResponse = ['exec' => 'invalid', 'status' => 200];
         $service = new PixPaymentVerificationService('http://example', 'token', 10);
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid response from Pix provider.');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
 // Test bootstrap
 session_start();
-?>
+
+require_once __DIR__ . '/CurlStubs.php';


### PR DESCRIPTION
## Summary
- centralize curl stubs used by payment tests
- include CurlStubs from bootstrap
- update payment verification tests to use the new stubs

## Testing
- `vendor/bin/phpunit` *(fails: DataValidationUtilsTest::testValidateZipCodeValid, DataValidationUtilsTest::testValidateZipCodeInvalidMissingHyphen, DataValidationUtilsTest::testValidateZipCodeInvalidLength, PdoDatabaseManagerTest::testListPaymentsWithStatusAndDebt)*

------
https://chatgpt.com/codex/tasks/task_e_6888d446f1e4832890cb36dbda9a376c