### PR TITLE
Fix sidebar stacking order

### DIFF
--- a/css/side-nav.css
+++ b/css/side-nav.css
@@ -10,7 +10,8 @@
     position: fixed;
     height: 100%;
     overflow-y: auto;
-    z-index: 1000;
+    /* Keep sidebar below Bootstrap dropdowns */
+    z-index: 900;
     transition: all 0.4s ease 0s;
 }
 


### PR DESCRIPTION
## Summary
- lower the sidebar z-index so dropdowns render correctly

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: DataValidationUtilsTest::testValidateZipCodeValid, DataValidationUtilsTest::testValidateZipCodeInvalidMissingHyphen, DataValidationUtilsTest::testValidateZipCodeInvalidLength, PdoDatabaseManagerTest::testListPaymentsWithStatusAndDebt)*

------
https://chatgpt.com/codex/tasks/task_e_688902c0df608328af00b10cdf79346d