### PR TITLE
Ensure jQuery and Bootstrap load order

### DIFF
--- a/tests/WidgetManagerTest.php
+++ b/tests/WidgetManagerTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace catechesis\gui {
+    require_once __DIR__ . '/../gui/widgets/Widget.php';
+    class DummyWidget extends Widget
+    {
+        public function __construct(array $deps, ?string $id = null)
+        {
+            parent::__construct($id);
+            foreach($deps as $d)
+                $this->addJSDependency($d);
+        }
+        public function renderHTML() {}
+    }
+}
+
+namespace {
+    use catechesis\gui\WidgetManager;
+    use catechesis\gui\DummyWidget;
+    use PHPUnit\Framework\TestCase;
+
+    require_once __DIR__ . '/../gui/widgets/WidgetManager.php';
+
+    class WidgetManagerTest extends TestCase
+    {
+        public function testRenderJSSortsCoreScriptsFirst(): void
+        {
+            $manager = new WidgetManager();
+
+            // Register widgets in an arbitrary order
+            $w1 = new DummyWidget(['js/bootstrap.bundle.min.js', 'c.js']);
+            $w2 = new DummyWidget(['js/jquery.min.js', 'b.js']);
+            $w3 = new DummyWidget(['d.js']);
+
+            $manager->addWidget($w1); // bootstrap first
+            $manager->addWidget($w2); // jquery second
+            $manager->addWidget($w3);
+
+            ob_start();
+            $manager->renderJS();
+            $output = ob_get_clean();
+
+            $expected = '<script src="js/jquery.min.js"></script>' .
+                        '<script src="js/bootstrap.bundle.min.js"></script>' .
+                        '<script src="c.js"></script>' .
+                        '<script src="b.js"></script>' .
+                        '<script src="d.js"></script>';
+
+            $this->assertEquals($expected, $output);
+        }
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- sort WidgetManager JS dependencies so jQuery loads first and Bootstrap second
- add regression test for new order

## Testing
- `vendor/bin/phpunit` *(fails: DataValidationUtilsTest and PdoDatabaseManagerTest)*

------
https://chatgpt.com/codex/tasks/task_e_68890de9bf58832881ee125d314ad129