### PR TITLE
Fix WidgetManager renderJS dependency handling

### DIFF
--- a/gui/widgets/WidgetManager.php
+++ b/gui/widgets/WidgetManager.php
@@ -159,7 +159,7 @@ namespace catechesis\gui
          */
         public function renderJS()
         {
-            $dependencies = array();
+            $rendered_js = array();
 
             // Gather additional dependencies directly declared in this manager
             foreach($this->_additional_js_dependencies as $path)


### PR DESCRIPTION
## Summary
- initialize `$rendered_js` in `WidgetManager::renderJS`
- remove unused `$dependencies` variable

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml tests/WidgetManagerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68891558fc8c83288989bba53a293c8d