### PR TITLE
Fix Configurator class reference in UserAccount widget

### DIFF
--- a/gui/widgets/configuration_panels/UserAccountConfigurationPanel/UserAccountConfigurationPanelWidget.php
+++ b/gui/widgets/configuration_panels/UserAccountConfigurationPanel/UserAccountConfigurationPanelWidget.php
@@ -5,10 +5,14 @@ namespace catechesis\gui;
 require_once(__DIR__ . '/../AbstractSettingsPanel/AbstractSettingsPanelWidget.php');
 require_once(__DIR__ . '/../../../../authentication/Authenticator.php');
 require_once(__DIR__ . '/../../../../core/PdoDatabaseManager.php');
+require_once(__DIR__ . '/../../../../core/Configurator.php');
+require_once(__DIR__ . '/../../../../core/domain/Locale.php');
 require_once(__DIR__ . '/../../../../core/Utils.php');
 
 use catechesis\Authenticator;
+use catechesis\Configurator;
 use catechesis\PdoDatabaseManager;
+use core\domain\Locale;
 use catechesis\Utils;
 use uLogin;
 


### PR DESCRIPTION
## Summary
- include the missing Configurator and Locale classes in `UserAccountConfigurationPanelWidget`

This resolves fatal `Class "catechesis\gui\Configurator" not found` errors when rendering user account settings.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68890bc06be48328ba76f966b92929d0