### PR TITLE
Fix warning when authorizations list is null

### DIFF
--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -1061,8 +1061,10 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
 
 
 		//Registar autorizacao de saida de menores
-        foreach($autorizacoes_saida_menores as $familiar)
+        if (is_array($autorizacoes_saida_menores) || is_object($autorizacoes_saida_menores))
         {
+            foreach($autorizacoes_saida_menores as $familiar)
+            {
             $name = $familiar->nome;
             $relationship = $familiar->parentesco;
             $phone = $familiar->telefone;
@@ -1090,6 +1092,7 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
 
             //Adiciona a' lista de familiares que podem vir buscar o catequizando
             addAuthorizationToList($cid, $name, $relationship, $phone);
+        }
         }
 
 


### PR DESCRIPTION
## Summary
- guard `foreach` on authorization list to avoid warnings

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6889225a828c8328ab5377ee3166a7dc