### PR TITLE
Add CSRF checks for user creation

### DIFF
--- a/criarUtilizador.php
+++ b/criarUtilizador.php
@@ -123,7 +123,8 @@ $menu->renderHTML();
 	    <div class="row" style="margin-bottom:20px; "></div>
 	    
 	    
-	    <form role="form" action="gerirUtilizadores.php" method="post" onsubmit="return valida_form();" id="form_criar_utilizador">
+            <form role="form" action="gerirUtilizadores.php" method="post" onsubmit="return valida_form();" id="form_criar_utilizador">
+                    <input type="hidden" name="csrf_token" value="<?= \catechesis\Utils::getCSRFToken() ?>">
 	    
 		    <!--nome-->
 		    <div class="form-group">

--- a/gerirUtilizadores.php
+++ b/gerirUtilizadores.php
@@ -108,8 +108,13 @@ $menu->renderHTML();
 <?php
 
 	//Criar conta
-	if(isset($_POST['op']) && $_POST['op']=="criar")
-	{
+        if(isset($_POST['op']) && $_POST['op']=="criar")
+        {
+                if(!Utils::verifyCSRFToken($_POST['csrf_token'] ?? null))
+                {
+                        echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Pedido inválido.</div>");
+                        die();
+                }
 
 		$un = Utils::sanitizeInput($_POST['un']);
 		$nome = Utils::sanitizeInput($_POST['nome']);


### PR DESCRIPTION
## Summary
- protect user creation form with CSRF token
- validate CSRF token before creating accounts

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688936e9026c8328881de98a0b61900b