### PR TITLE
Fix nullable parameter warnings

### DIFF
--- a/core/UserData.php
+++ b/core/UserData.php
@@ -118,7 +118,7 @@ class UserData
      * Returns the path of the file where the photo was saved, relative to the CatecheSis user data directory.
      * @throws Exception
      */
-    public static function saveUploadedCatechumenPhoto(string $imageData, string $filename = null)
+    public static function saveUploadedCatechumenPhoto(string $imageData, ?string $filename = null)
     {
         $path = self::saveUploadedPhoto($imageData, self::CATECHUMEN_PHOTOS_DIR, $filename, ["image/jpeg", "image/png"]);
 
@@ -160,7 +160,7 @@ class UserData
      * @return string|null
      * @throws Exception
      */
-    public static function saveUploadedPhoto(string $imageData, string $directory, string $filename = null, array $allowedTypes = ["image/jpeg", "image/png"]): ?string
+    public static function saveUploadedPhoto(string $imageData, string $directory, ?string $filename = null, array $allowedTypes = ["image/jpeg", "image/png"]): ?string
     {
         $MAX_SIZE = 5 * (1024 * 1024); // 5 MB
 

--- a/core/Utils.php
+++ b/core/Utils.php
@@ -99,7 +99,7 @@ class Utils
      * @param $parish
      * @return int
      */
-    public static function sacramentParish(string $parish = null)
+    public static function sacramentParish(?string $parish = null)
     {
         if ($parish && $parish != "")
         {
@@ -129,7 +129,7 @@ class Utils
      *
      * @return false|float|int|string
      */
-    public static function currentCatecheticalYear(string $date = null)
+    public static function currentCatecheticalYear(?string $date = null)
     {
         return Utils::computeCatecheticalYear(null);
     }
@@ -140,7 +140,7 @@ class Utils
      *
      * @return false|float|int|string
      */
-    public static function computeCatecheticalYear(string $date = null)
+    public static function computeCatecheticalYear(?string $date = null)
     {
         $ano_actual = date("Y");
         $mes_actual = date("m");
@@ -209,7 +209,7 @@ class Utils
      * @param $data
      * @return string
      */
-    public static function sanitizeInput(string $data = null)
+    public static function sanitizeInput(?string $data = null)
     {
         $data = trim($data);
         $data = stripslashes($data);
@@ -223,7 +223,7 @@ class Utils
      * @param $data
      * @return string
      */
-    public static function sanitizeOutput(string $data = null)
+    public static function sanitizeOutput(?string $data = null)
     {
         $data = trim($data);
         $data = stripslashes($data);

--- a/core/enrollment_functions.php
+++ b/core/enrollment_functions.php
@@ -27,7 +27,7 @@ use catechesis\UserData;
  * @return bool
  */
 function setRenewalOrderStatus(int $rid, bool $status,
-                               int $enrollmentCatecheticalYear = null, int $enrollmentCatechism = null, string $enrollmentGroup = null)
+                               ?int $enrollmentCatecheticalYear = null, ?int $enrollmentCatechism = null, ?string $enrollmentGroup = null)
 {
     $db = new PdoDatabaseManager();
 
@@ -110,7 +110,7 @@ function deleteRenewalOrder(int $rid)
  * @param $eid - Enrollment order ID
  * @param $cid - ID of the catechumen to associate with the processed order (or null, to process without associating a file)
  */
-function setEnrollmentOrderAsProcessed(int $eid, int $cid = null)
+function setEnrollmentOrderAsProcessed(int $eid, ?int $cid = null)
 {
     $db = new PdoDatabaseManager();
 

--- a/gui/widgets/AboutDialog/AboutDialogWidget.php
+++ b/gui/widgets/AboutDialog/AboutDialogWidget.php
@@ -13,7 +13,7 @@ require_once(__DIR__ . "/../../../core/version_info.php");
 
 class AboutDialogWidget extends ModalDialogWidget
 {
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
 

--- a/gui/widgets/AbstractCatechumensListing/AbstractCatechumensListingWidget.php
+++ b/gui/widgets/AbstractCatechumensListing/AbstractCatechumensListingWidget.php
@@ -14,7 +14,7 @@ abstract class AbstractCatechumensListingWidget extends Widget
     protected /*string*/ $additional_toolbar_buttons = null;  // Any user-defined HTML buttons to add to the widget toolbar
 
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
 

--- a/gui/widgets/CatechumensList/CatechumensListWidget.php
+++ b/gui/widgets/CatechumensList/CatechumensListWidget.php
@@ -25,7 +25,7 @@ class CatechumensListWidget extends AbstractCatechumensListingWidget
     private /*PDO result array*/ $catechumens_list;         // Stores the list of catechumens to show in the list widget
     private /*string*/ $entities_name = "resultado";        // Name to use in the results header to refer to the entities in the list (e.g. "results" or "catechumens")
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
         // This widget's dependencies are inherited from AbstractCatechumensListingWidget

--- a/gui/widgets/CatechumensProblemsReportSummary/CatechumensProblemsReportSummaryWidget.php
+++ b/gui/widgets/CatechumensProblemsReportSummary/CatechumensProblemsReportSummaryWidget.php
@@ -24,7 +24,7 @@ class CatechumensProblemsReportSummaryWidget extends Widget
 {
     private /*string*/ $_username;  // The username of the catechist for which this widget will display info
 
-    public function __construct(string $id = null, string $catechistUsername = null)
+    public function __construct(?string $id = null, ?string $catechistUsername = null)
     {
         parent::__construct($id);
 

--- a/gui/widgets/CatechumensReport/CatechumensReportWidget.php
+++ b/gui/widgets/CatechumensReport/CatechumensReportWidget.php
@@ -26,7 +26,7 @@ class CatechumensReportWidget extends AbstractCatechumensListingWidget
     private /*array*/  $report_contents;                    // Stores groups of lists of catechumens to show in each of the report widget accordions
 
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
         // This widget's dependencies are inherited from AbstractCatechumensListingWidget
@@ -47,7 +47,7 @@ class CatechumensReportWidget extends AbstractCatechumensListingWidget
     * @param string|null $emptyString - string to be shown in case there are no results in this group
     * @return $this
     */
-    public function addCatechumensList(string $header, array $catechumensList, bool $startExpanded = false, string $emptyString = null)
+    public function addCatechumensList(string $header, array $catechumensList, bool $startExpanded = false, ?string $emptyString = null)
     {
         $reportEntry = array();
         $reportEntry["header"] = $header;

--- a/gui/widgets/Footer/SimpleFooter.php
+++ b/gui/widgets/Footer/SimpleFooter.php
@@ -14,7 +14,7 @@ class SimpleFooter extends Widget
 {
     private /*bool*/ $_with_background = false;     // Defined whether the footer should have a blue background color (true) or be transparent (false)
 
-    public function __construct(string $id = null, bool $withBackground=false)
+    public function __construct(?string $id = null, bool $withBackground=false)
     {
         parent::__construct($id);
 

--- a/gui/widgets/ModalDialog/ModalDialogWidget.php
+++ b/gui/widgets/ModalDialog/ModalDialogWidget.php
@@ -19,7 +19,7 @@ class ModalDialogWidget extends Widget
     private $exitAnimation = Animation::FADE_OUT_UP;
 
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
 

--- a/gui/widgets/MyGroups/MyGroupsWidget.php
+++ b/gui/widgets/MyGroups/MyGroupsWidget.php
@@ -21,7 +21,7 @@ class MyGroupsWidget extends Widget
 {
     private /*string*/ $_username;  // The username of the catechist for which this widget will display info
 
-    public function __construct(string $id = null, string $catechistUsername = null)
+    public function __construct(?string $id = null, ?string $catechistUsername = null)
     {
         parent::__construct($id);
 

--- a/gui/widgets/Navbar/MainNavbar.php
+++ b/gui/widgets/Navbar/MainNavbar.php
@@ -44,7 +44,7 @@ class MainNavbar extends Widget
     private /*UpdateDialogWidget*/  $updateDialog = null;                   // The update notification window
 
 
-    public function __construct(string $id = null, int $menuOption, bool $allowsSiblingEnrollment=False)
+    public function __construct(?string $id = null, int $menuOption, bool $allowsSiblingEnrollment=False)
     {
         parent::__construct($id);
 

--- a/gui/widgets/QuickAccess/QuickAccessWidget.php
+++ b/gui/widgets/QuickAccess/QuickAccessWidget.php
@@ -22,7 +22,7 @@ use RELATORIO;
  */
 class QuickAccessWidget extends Widget
 {
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
 

--- a/gui/widgets/SacramentList/SacramentListWidget.php
+++ b/gui/widgets/SacramentList/SacramentListWidget.php
@@ -24,7 +24,7 @@ class SacramentListWidget extends AbstractCatechumensListingWidget
     private /*string*/ $entities_name_singular = "resultado";   // Name to use in the results header to refer to the entities in the list (e.g. "results" or "baptisms")
     private /*string*/ $entities_name_plural = "resultados";    // Plural form of the previous string
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
         // This widget's dependencies are inherited from AbstractCatechumensListingWidget
@@ -56,7 +56,7 @@ class SacramentListWidget extends AbstractCatechumensListingWidget
      * @param string $name
      * @return $this
      */
-    public function setEntitiesName(string $singular, string $plural = null)
+    public function setEntitiesName(string $singular, ?string $plural = null)
     {
         $this->entities_name_singular = $singular;
 

--- a/gui/widgets/SacramentRecordPanel/SacramentRecordPanelWidget.php
+++ b/gui/widgets/SacramentRecordPanel/SacramentRecordPanelWidget.php
@@ -32,7 +32,7 @@ class SacramentRecordPanelWidget extends AbstractSettingsPanelWidget
     private /*string*/ $_proof_file = null;     // Sacrament proof file name
     private $_deleteProofDialog = null;         // Dialog to confirm removal of sacrament proof
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id, false);
 
@@ -517,7 +517,7 @@ class SacramentRecordPanelWidget extends AbstractSettingsPanelWidget
      * @param string $parish
      * @return void
      */
-    private function updateSacramentSessionData(bool $hasSacrament, string $sacramentDate = null, string $parish = null)
+    private function updateSacramentSessionData(bool $hasSacrament, ?string $sacramentDate = null, ?string $parish = null)
     {
         switch($this->_sacrament)
         {
@@ -560,7 +560,7 @@ class SacramentRecordPanelWidget extends AbstractSettingsPanelWidget
      * @param string|null $sacramentProof
      * @return void
      */
-    private function updateSacramentProofSessionData(string $sacramentProof = null)
+    private function updateSacramentProofSessionData(?string $sacramentProof = null)
     {
         switch($this->_sacrament)
         {

--- a/gui/widgets/UpdateDialog/UpdateDialogWidget.php
+++ b/gui/widgets/UpdateDialog/UpdateDialogWidget.php
@@ -16,7 +16,7 @@ use catechesis\Authenticator;
 
 class UpdateDialogWidget extends ModalDialogWidget
 {
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
 

--- a/gui/widgets/configuration_panels/AbstractSettingsPanel/AbstractSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/AbstractSettingsPanel/AbstractSettingsPanelWidget.php
@@ -17,7 +17,7 @@ abstract class AbstractSettingsPanelWidget extends Widget
     protected /*string*/ $panel_style = "panel-default";    // Bootstrap style to apply to this panel (e.g. 'panel-default', 'panel-success', ...)
     protected /*bool*/   $requires_admin_privileges = true; // Whether this widget can only be shown to admin users
 
-    public function __construct(string $id = null, bool $requires_admin_privileges=true)
+    public function __construct(?string $id = null, bool $requires_admin_privileges=true)
     {
         parent::__construct($id);
 

--- a/gui/widgets/configuration_panels/CatechesisSettingsPanel/CatechesisSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/CatechesisSettingsPanel/CatechesisSettingsPanelWidget.php
@@ -26,7 +26,7 @@ class CatechesisSettingsPanelWidget extends AbstractSettingsPanelWidget
 {
     public static $ACTION_PARAMETER = "edit_catechesis_operational_settings";
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id, true);
 

--- a/gui/widgets/configuration_panels/CatechumensEvaluationActivationPanel/CatechumensEvaluationActivationPanelWidget.php
+++ b/gui/widgets/configuration_panels/CatechumensEvaluationActivationPanel/CatechumensEvaluationActivationPanelWidget.php
@@ -23,7 +23,7 @@ class CatechumensEvaluationActivationPanelWidget extends AbstractSettingsPanelWi
 {
     public static $ACTION_PARAMETER = "edit_evaluation_period_status";
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id, true);
 

--- a/gui/widgets/configuration_panels/FrontPageCustomizationPanel/FrontPageCustomizationPanelWidget.php
+++ b/gui/widgets/configuration_panels/FrontPageCustomizationPanel/FrontPageCustomizationPanelWidget.php
@@ -25,7 +25,7 @@ class FrontPageCustomizationPanelWidget extends AbstractSettingsPanelWidget
 {
     public static $ACTION_PARAMETER = "customize_front_page";
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id);
 

--- a/gui/widgets/configuration_panels/GDPRParishSettingsPanel/GDPRParishSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/GDPRParishSettingsPanel/GDPRParishSettingsPanelWidget.php
@@ -26,7 +26,7 @@ class GDPRParishSettingsPanelWidget extends AbstractSettingsPanelWidget
 {
     public static $ACTION_PARAMETER = "edit_parish_gdpr_details";
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id, true);
 

--- a/gui/widgets/configuration_panels/NextcloudIntegrationConfigurationPanel/NextcloudIntegrationConfigurationPanelWidget.php
+++ b/gui/widgets/configuration_panels/NextcloudIntegrationConfigurationPanel/NextcloudIntegrationConfigurationPanelWidget.php
@@ -23,7 +23,7 @@ class NextcloudIntegrationConfigurationPanelWidget extends AbstractSettingsPanel
 {
     public static $ACTION_PARAMETER = "edit_nextcloud_integration";
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id, true);
 

--- a/gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php
+++ b/gui/widgets/configuration_panels/OnlineEnrollmentsActivationPanel/OnlineEnrollmentsActivationPanelWidget.php
@@ -26,7 +26,7 @@ class OnlineEnrollmentsActivationPanelWidget extends AbstractSettingsPanelWidget
     public static $ACTION_CHANGE_DETAILS = "edit_online_enrollments_details";
     private /*bool*/ $showAllSettings = true;
 
-    public function __construct(string $id = null, bool $showAllSettings = true)
+    public function __construct(?string $id = null, bool $showAllSettings = true)
     {
         parent::__construct($id, true);
 

--- a/gui/widgets/configuration_panels/ParishSettingsPanel/ParishSettingsPanelWidget.php
+++ b/gui/widgets/configuration_panels/ParishSettingsPanel/ParishSettingsPanelWidget.php
@@ -28,7 +28,7 @@ class ParishSettingsPanelWidget extends AbstractSettingsPanelWidget
 {
     public static $ACTION_PARAMETER = "edit_parish_details";
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id, true);
 

--- a/gui/widgets/configuration_panels/UserAccountConfigurationPanel/UserAccountConfigurationPanelWidget.php
+++ b/gui/widgets/configuration_panels/UserAccountConfigurationPanel/UserAccountConfigurationPanelWidget.php
@@ -28,7 +28,7 @@ class UserAccountConfigurationPanelWidget extends AbstractSettingsPanelWidget
     private /*string*/ $userAccount = null;                         //Username to edit with this widget
 
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct($id, false);
 


### PR DESCRIPTION
## Summary
- add nullable types for optional parameters in widgets
- adjust UserData and Utils helpers
- update enrollment helper signatures

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6889710300d483289f1a3951c3c229f3