### PR TITLE
Fix session secure parameter

### DIFF
--- a/core/session_init.php
+++ b/core/session_init.php
@@ -8,7 +8,7 @@ if (session_status() === PHP_SESSION_NONE) {
         'path' => '/',
         // NÃO defina 'domain' em localhost, deixe o padrão!
         // 'domain' => '',  // REMOVA ESSA LINHA!
-        'secure' => true, // Se usar https, deve ser true!
+        'secure' => constant('CATECHESIS_HTTPS'), // Se usar https, deve ser true!
         'httponly' => true,
         'samesite' => 'Lax'
     ]);


### PR DESCRIPTION
## Summary
- use `CATECHESIS_HTTPS` constant for session cookie `secure` flag

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68897685c42083288117c24c60cf72c9