### PR TITLE
Use env var for data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All configuration lives under `core/config/`:
 - `catechesis_config.inc.template.php` – template used to create the configuration file.
 - `catechesis_config.inc.docker.php` – example configuration used inside containers.
 
-The file defines the base URL, domain name, local paths and the location of the external data directory that stores sensitive data. Copy the template file and adjust the constants to match your environment.
+The file defines the base URL, domain name, local paths and the location of the external data directory that stores sensitive data. Copy the template file and adjust the constants to match your environment.  The data directory can also be configured through the `CATECHESIS_DATA_DIRECTORY` environment variable, which overrides the path defined in the configuration file.
 
 Additional sensitive options are loaded from `CATECHESIS_DATA_DIRECTORY/config/catechesis_config.shadow.php` which should be located outside the web root.
 

--- a/core/config/catechesis_config.inc.docker.php
+++ b/core/config/catechesis_config.inc.docker.php
@@ -35,7 +35,13 @@ define('CATECHESIS_ROOT_DIRECTORY', '/var/www/html/');
 //CatecheSis data directory
 //  The server directory where user-generated data is stored.
 //  This directory should be outside the public_html folder, to guarantee it is NOT accessible through a browser.
-define('CATECHESIS_DATA_DIRECTORY', '/home/catechesis_data');
+if (!defined('CATECHESIS_DATA_DIRECTORY')) {
+    $dataDir = getenv('CATECHESIS_DATA_DIRECTORY');
+    if ($dataDir === false || $dataDir === '') {
+        $dataDir = '/home/catechesis_data';
+    }
+    define('CATECHESIS_DATA_DIRECTORY', $dataDir);
+}
 
 
 // Load the remaining configurations from file

--- a/core/config/catechesis_config.inc.php
+++ b/core/config/catechesis_config.inc.php
@@ -37,7 +37,13 @@ if (!defined('CATECHESIS_ROOT_DIRECTORY')) {
 //CatecheSis data directory
 //  The server directory where user-generated data is stored.
 //  This directory should be outside the public_html folder, to guarantee it is NOT accessible through a browser.
-define('CATECHESIS_DATA_DIRECTORY', 'C:/xampp/catechesis-data');
+if (!defined('CATECHESIS_DATA_DIRECTORY')) {
+    $dataDir = getenv('CATECHESIS_DATA_DIRECTORY');
+    if ($dataDir === false || $dataDir === '') {
+        $dataDir = 'C:/xampp/catechesis-data';
+    }
+    define('CATECHESIS_DATA_DIRECTORY', $dataDir);
+}
 
 
 // Load the remaining configurations from file if available

--- a/core/config/catechesis_config.inc.template.php
+++ b/core/config/catechesis_config.inc.template.php
@@ -35,7 +35,13 @@ define('CATECHESIS_ROOT_DIRECTORY', '<CATECHESIS_ROOT_DIRECTORY>');
 //CatecheSis data directory
 //  The server directory where user-generated data is stored.
 //  This directory should be outside the public_html folder, to guarantee it is NOT accessible through a browser.
-define('CATECHESIS_DATA_DIRECTORY', '<CATECHESIS_DATA_DIRECTORY>');
+if (!defined('CATECHESIS_DATA_DIRECTORY')) {
+    $dataDir = getenv('CATECHESIS_DATA_DIRECTORY');
+    if ($dataDir === false || $dataDir === '') {
+        $dataDir = '<CATECHESIS_DATA_DIRECTORY>';
+    }
+    define('CATECHESIS_DATA_DIRECTORY', $dataDir);
+}
 
 
 // Load the remaining configurations from file


### PR DESCRIPTION
## Summary
- let `CATECHESIS_DATA_DIRECTORY` be set by an environment variable
- document the new environment variable

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a5d4a120483289f043050cb9f6340