### PR TITLE
Handle exceptions generically

### DIFF
--- a/estatisticaDesistencias.php
+++ b/estatisticaDesistencias.php
@@ -131,7 +131,8 @@ $menu->renderHTML();
       }
       catch(Exception $e)
       {
-          echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . $e->getMessage() . "</div>");
+          error_log($e->getMessage());
+          echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> Ocorreu um erro ao obter os dados necessários.</div>");
           die();
       }
  ?>
@@ -295,7 +296,8 @@ $("#grafico1").bind("plothover", function (event, pos, item) {
 	}
     catch (Exception $e)
     {
-        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . $e->getMessage() . "</div>");
+        error_log($e->getMessage());
+        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> Não foi possível gerar o gráfico.</div>");
         die();
     }
 
@@ -431,11 +433,12 @@ $("#grafico2").bind("plothover", function (event, pos, item) {
 	
 <?php
 	}
-	catch(Exception $e)
+        catch(Exception $e)
     {
-        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> " . $e->getMessage() . "</div>");
+        error_log($e->getMessage());
+        echo("<div class=\"alert alert-danger\"><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a><strong>Erro!</strong> Não foi possível gerar o gráfico.</div>");
         die();
-	}	    
+        }
 		    
 		    
 	//Libertar recursos

--- a/pagamentos.php
+++ b/pagamentos.php
@@ -59,7 +59,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['cid'])) {
             $message = "<div class='alert alert-success'><strong>Sucesso!</strong> Pagamento registado.</div>";
         } catch (Exception $e) {
             $db->rollBack();
-            $message = "<div class='alert alert-danger'><strong>Erro!</strong> " . $e->getMessage() . "</div>";
+            error_log($e->getMessage());
+            $message = "<div class='alert alert-danger'><strong>Erro!</strong> Não foi possível registar o pagamento.</div>";
         }
 }
 }
@@ -70,14 +71,16 @@ if(Authenticator::isAdmin()) {
         $paymentList = $db->getEnrollmentPaymentStatusList(Utils::currentCatecheticalYear());
     } catch (Exception $e) {
         $paymentList = [];
-        $message = "<div class='alert alert-danger'><strong>Erro!</strong> " . $e->getMessage() . "</div>";
+        error_log($e->getMessage());
+        $message = "<div class='alert alert-danger'><strong>Erro!</strong> Não foi possível obter a lista de pagamentos.</div>";
     }
 } else {
     try {
         $payments = $db->getPaymentsByUser(Authenticator::getUsername());
     } catch (Exception $e) {
         $payments = [];
-        $message = "<div class='alert alert-danger'><strong>Erro!</strong> " . $e->getMessage() . "</div>";
+        error_log($e->getMessage());
+        $message = "<div class='alert alert-danger'><strong>Erro!</strong> Não foi possível obter os pagamentos.</div>";
     }
 }
 


### PR DESCRIPTION
## Summary
- show generic error messages on estatística and payments pages
- log the detailed exception server-side

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a5d4b32f48328a1b0943b2854e004