### PR TITLE
Include catechesis_config before session init

### DIFF
--- a/login.php
+++ b/login.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/core/session_init.php');
 require_once(__DIR__ . '/authentication/Authenticator.php');
 require_once(__DIR__ . '/core/Configurator.php');


### PR DESCRIPTION
## Summary
- load catechesis configuration before starting sessions in `login.php`

## Testing
- `composer install`
- `vendor/bin/phpunit`
- `php -S localhost:8000` then `curl http://localhost:8000/login.php`

------
https://chatgpt.com/codex/tasks/task_e_688a630ed1d88328b97c6ed8f57b69a6