### PR TITLE
Fix user creation form Configurator inclusion

### DIFF
--- a/criarUtilizador.php
+++ b/criarUtilizador.php
@@ -4,15 +4,19 @@ require_once(__DIR__ . '/core/config/catechesis_config.inc.php');
 require_once(__DIR__ . '/authentication/utils/authentication_verify.php');
 require_once(__DIR__ . '/authentication/Authenticator.php');
 require_once(__DIR__ . '/core/Utils.php');
+require_once(__DIR__ . '/core/Configurator.php');
+require_once(__DIR__ . '/core/domain/Locale.php');
 require_once(__DIR__ . "/core/PdoDatabaseManager.php");
 require_once(__DIR__ . "/gui/widgets/WidgetManager.php");
 require_once(__DIR__ . '/gui/widgets/Navbar/MainNavbar.php');
 
 use catechesis\Authenticator;
+use catechesis\Configurator;
 use catechesis\PdoDatabaseManager;
 use catechesis\gui\WidgetManager;
 use catechesis\gui\MainNavbar;
 use catechesis\gui\MainNavbar\MENU_OPTION;
+use core\domain\Locale;
 
 
 // Create the widgets manager


### PR DESCRIPTION
## Summary
- include Configurator and Locale dependencies in `criarUtilizador.php`
- add required `use` statements

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688a6232b4d88328a1afe724d5cc48b9