### PR TITLE
Enable Pix payments for enrolments

### DIFF
--- a/core/PixQRCode.php
+++ b/core/PixQRCode.php
@@ -57,8 +57,8 @@ class PixQRCode{
     public static function generatePixQRCode(?float $amount): string{
 
         $key  = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_KEY);
-        $name = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_NAME);
-        $city = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_CITY);
+        $name = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_RECEIVER);
+        $city = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_CITY);
         $desc = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_DESCRIPTION) ?? '';
         $txid = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_TXID) ?? '***';
 
@@ -85,8 +85,8 @@ class PixQRCode{
 
     public static function generatePixPayload(?float $amount): string{
         $key  = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_KEY);
-        $name = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_NAME);
-        $city = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_MERCHANT_CITY);
+        $name = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_RECEIVER);
+        $city = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_CITY);
         $desc = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_DESCRIPTION) ?? '';
         $txid = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_TXID) ?? '***';
 


### PR DESCRIPTION
## Summary
- use correct Configurator keys in `PixQRCode`
- show payment history and Pix QR code on payment page

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a68b19bfc8328817f16191eefba75