### PR TITLE
Improve QrCode autoload and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 CatecheSis is a web application for managing catechesis records and online enrollments.
 
+## Quick start
+
+Before using the application you must install its PHP dependencies. From the
+project root run:
+
+```bash
+composer install
+```
+
+This command installs the autoloader and all required packages.
+
 ## Prerequisites
 
 CatecheSis requires a standard LAMP stack. Recommended software versions are:

--- a/resources/phpqrcode/QrCode.php
+++ b/resources/phpqrcode/QrCode.php
@@ -1,7 +1,11 @@
 <?php
 namespace resources\phpqrcode;
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+$autoload = dirname(__DIR__, 2) . '/vendor/autoload.php';
+if (!is_file($autoload)) {
+    throw new \RuntimeException('Dependencies missing. Run "composer install".');
+}
+require_once $autoload;
 
 use Endroid\QrCode\Builder\Builder;
 use Endroid\QrCode\Writer\PngWriter;


### PR DESCRIPTION
## Summary
- add quick start section to README
- document requirement to install Composer dependencies
- check QrCode autoload path before requiring

## Testing
- `composer install`
- `php pagamentos.php`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a6e6e939883288c386deecb211422