### PR TITLE
Allow enrollment by non-admins

### DIFF
--- a/gui/widgets/Navbar/MainNavbar.php
+++ b/gui/widgets/Navbar/MainNavbar.php
@@ -133,25 +133,20 @@ class MainNavbar extends Widget
                         <!-- Dashboard -->
                         <li<?php if($this->menuOption==MENU_OPTION::HOME) echo(' class="active"'); ?>><a href="dashboard.php"><i class="fas fa-home"></i> </a></li>
 
-                        <?php
-                        if(Authenticator::isAdmin())
-                        {
-                            ?>
-                            <!-- Enrollments -->
-                            <li class="dropdown<?php if($this->menuOption==MENU_OPTION::ENROLMENTS) echo(', active'); ?>"><a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="fas fa-signature"></i> Inscrições <?php if($totalPendingEnrollmentsAndRenewals > 0) echo("<span class=\"badge\">" . $totalPendingEnrollmentsAndRenewals . "</span> ");?><span class="caret"></span></a>
-                                <ul class="dropdown-menu">
-                                    <li role="presentation" class="dropdown-header"><i class="fas fa-edit"></i> Inscrições e renovações</li>
-                                    <li><a href="inscricao.php">Cadastrar novo catequizando</a></li>
-                                    <li class="<?php if(!$this->allowsSiblingEnrollment) echo('disabled'); ?>"><a href="<?php if($this->allowsSiblingEnrollment) echo('inscricao.php?modo=irmao'); ?>">Inscrever um irmão deste catequizando</a></li>
-                                    <li><a href="renovacaoMatriculas.php">Renovar matrículas <?php if($pendingRenewals > 0) echo("<span class=\"badge\">" . $pendingRenewals . "</span>");?></a></li>
-                                    <li class="divider"></li>
-                                    <li role="presentation" class="dropdown-header"><i class="fas fa-globe-europe"></i> Inscrições online</li>
-                                    <li><a href="processarInscricoesOnline.php">Processar pedidos de inscrição online <?php if($pendingEnrollments > 0) echo("<span class=\"badge\">" . $pendingEnrollments . "</span>");?></a></li>
-                                </ul>
-                            </li>
-                        <?php
-                        }
-                        ?>
+                        <!-- Enrollments -->
+                        <li class="dropdown<?php if($this->menuOption==MENU_OPTION::ENROLMENTS) echo(', active'); ?>"><a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="fas fa-signature"></i> Inscrições <?php if($totalPendingEnrollmentsAndRenewals > 0) echo("<span class=\"badge\">" . $totalPendingEnrollmentsAndRenewals . "</span> ");?><span class="caret"></span></a>
+                            <ul class="dropdown-menu">
+                                <li role="presentation" class="dropdown-header"><i class="fas fa-edit"></i> Inscrições e renovações</li>
+                                <li><a href="inscricao.php">Cadastrar novo catequizando</a></li>
+                                <li class="<?php if(!$this->allowsSiblingEnrollment) echo('disabled'); ?>"><a href="<?php if($this->allowsSiblingEnrollment) echo('inscricao.php?modo=irmao'); ?>">Inscrever um irmão deste catequizando</a></li>
+                                <li><a href="renovacaoMatriculas.php">Renovar matrículas <?php if($pendingRenewals > 0) echo("<span class=\"badge\">" . $pendingRenewals . "</span>");?></a></li>
+                                <li class="divider"></li>
+                                <li role="presentation" class="dropdown-header"><i class="fas fa-globe-europe"></i> Inscrições online</li>
+                                <?php if(Authenticator::isAdmin()) { ?>
+                                <li><a href="processarInscricoesOnline.php">Processar pedidos de inscrição online <?php if($pendingEnrollments > 0) echo("<span class=\"badge\">" . $pendingEnrollments . "</span>");?></a></li>
+                                <?php } ?>
+                            </ul>
+                        </li>
 
                         <!-- Catechumens -->
                         <li class="dropdown<?php if($this->menuOption==MENU_OPTION::CATECHUMENS) echo(', active'); ?>"><a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="fas fa-search"></i> Catequizandos<span class="caret"></span></a>

--- a/inscricao.php
+++ b/inscricao.php
@@ -80,12 +80,6 @@ $menu->renderHTML();
     {
         echo('<h2>Matrícula e inscrição na catequese</h2>');
 
-        if(!Authenticator::isAdmin())
-        {
-            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Não tem permissões para aceder a este recurso.</div>");
-            echo("</div></body></html>");
-            die();
-        }
     }
   	?>
   

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -89,12 +89,6 @@ $menu->renderHTML();
     {
         echo("<h2>Matrícula e inscrição na catequese</h2>");
 
-        if(!Authenticator::isAdmin())
-        {
-            echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Não tem permissões para aceder a este recurso.</div>");
-            echo("</div></body></html>");
-            die();
-        }
     }
 
 

--- a/renovacaoMatriculas.php
+++ b/renovacaoMatriculas.php
@@ -136,14 +136,6 @@ $menu->renderHTML();
  <div>
 <?php
 
-if(!Authenticator::isAdmin())
-{
-    echo("<div class=\"alert alert-danger\"><strong>Erro!</strong> Não tem permissões para aceder a este recurso.</div>");
-    echo("</div></body></html>");
-    die();
-
-}
-
 
 $username = Authenticator::getUsername();
 $db = new PdoDatabaseManager();


### PR DESCRIPTION
## Summary
- drop the admin guard around the Inscrições dropdown in the navbar
- keep online request processing visible only to admins
- remove admin-only checks from inscrição, processarInscricao and renovacaoMatriculas

## Testing
- `composer install`
- `vendor/bin/phpunit --dont-report-useless-tests`

------
https://chatgpt.com/codex/tasks/task_e_688a73753ec08328912fa66f35694078