### PR TITLE
Add registration link to login screen

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -179,3 +179,14 @@ input::placeholder
     font-weight: bold;
     background-color: rgb(20, 85, 148);
 }
+
+.register_help_text
+{
+    font-family: Nexa, sans-serif;
+    font-weight: bold;
+    text-align: center;
+    font-size: small;
+    color: #008fcf;
+    display: block;
+    margin-top: 20px;
+}

--- a/login.php
+++ b/login.php
@@ -238,6 +238,8 @@ $pageUI->addWidget($footer);
                         <button id="login_button" type="submit" class="btn btn-primary"><strong>Iniciar sessão</strong></button>
                     </form>
 
+                    <a class="register_help_text" href="register.php">Ainda não tem conta? Cadastre-se aqui!</a>
+
                     <div class="row" style="margin-bottom: 80px;"></div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add a visible "Cadastre-se" link below the login form
- style sign-up link in login page CSS

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a807b4c2083288a0a1b2f67f4c006