### PR TITLE
Display Pix payment payload

### DIFF
--- a/core/PixQRCode.php
+++ b/core/PixQRCode.php
@@ -50,6 +50,24 @@ class PixQRCode{
         return $payload;
     }
 
+    /**
+     * Generate and return the Pix payload string for the specified amount.
+     * This helper works even when the QR code library is missing.
+     */
+    public static function generatePixPayload(?float $amount): string
+    {
+        $key  = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_KEY);
+        $name = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_RECEIVER);
+        $city = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_CITY);
+        $desc = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_DESCRIPTION) ?? '';
+        $txid = Configurator::getConfigurationValueOrDefault(Configurator::KEY_PIX_TXID) ?? '***';
+
+        if(!$key || !$name || !$city){
+            throw new Exception('Pix configuration incomplete');
+        }
+
+        return self::buildPayload($key, $name, $city, $txid, $amount, $desc);
+    }
 
  public static function generatePixQRCode(?float $amount): ?string{
 

--- a/pagamentos.php
+++ b/pagamentos.php
@@ -204,9 +204,10 @@ $menu->renderHTML();
       <?php } ?>
       </tbody>
     </table>
-    <p>Situação: <?= $situation ?></p>
+    <p>Valor da taxa: R$<?= number_format($price, 2, ',', '.') ?></p>
     <p>Total pago: R$<?= number_format($total_confirmed, 2, ',', '.') ?></p>
     <p>Valor em aberto: R$<?= number_format($balance, 2, ',', '.') ?></p>
+    <p>Situação: <?= $situation ?></p>
 
     <?php if($balance > 0 && $pixPayload) { ?>
         <div style="margin-top:20px;text-align:center;">

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -12,6 +12,7 @@ require_once(__DIR__ . "/core/DataValidationUtils.php");
 require_once(__DIR__ . '/core/catechist_belongings.php');
 require_once(__DIR__ . "/core/PdoDatabaseManager.php");
 require_once(__DIR__ . '/core/PaymentVerificationService.php');
+require_once(__DIR__ . '/core/PixQRCode.php');
 require_once(__DIR__ . "/core/domain/Sacraments.php");
 require_once(__DIR__ . "/core/domain/Marriage.php");
 require_once(__DIR__ . "/gui/widgets/WidgetManager.php");
@@ -24,6 +25,7 @@ use catechesis\Configurator;
 use catechesis\UserData;
 use catechesis\utils;
 use catechesis\PaymentVerificationService;
+use catechesis\PixQRCode;
 use core\domain\Marriage;
 use core\domain\Sacraments;
 use catechesis\gui\WidgetManager;
@@ -1159,11 +1161,17 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
 
         if($_REQUEST['modo']!="editar")
         {
-                $pixPayload = strtoupper(Utils::secureRandomString(20));
+                try {
+                    $pixPayload = \catechesis\PixQRCode::generatePixPayload($payment_amount);
+                } catch (Exception $e) {
+                    $pixPayload = null;
+                }
                 echo("<p><strong>Taxa de inscrição: R$ " . number_format($payment_amount, 2, ',', '.') . "</strong></p>");
-                echo("<p>Pix \"copia e cola\" para pagamento:</p>");
-                echo("<pre style=\"white-space: pre-wrap; word-wrap: break-word;\">" . $pixPayload . "</pre>");
-                echo("<p>Você pode pagar qualquer valor agora e completar depois acessando o menu \"Pagamento\". O sistema atualizará automaticamente o valor restante e o status do seu pagamento.</p>");
+                if($pixPayload) {
+                    echo("<p>Pix \"copia e cola\" para pagamento:</p>");
+                    echo("<pre style=\"white-space: pre-wrap; word-wrap: break-word;\">" . $pixPayload . "</pre>");
+                }
+                echo("<p>Voce pode pagar parte do valor agora e completar depois acessando o menu \"Pagamentos\". O sistema atualizara automaticamente o restante e o status do pagamento.</p>");
         }
 	
 	

--- a/publico/doInscrever.php
+++ b/publico/doInscrever.php
@@ -529,6 +529,7 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
                             <div style="margin-top:20px;text-align:center;">
                                 <p>Pix copia e cola:</p>
                                 <pre style="white-space: pre-wrap; word-wrap: break-word;"><?php echo $pixPayload; ?></pre>
+                                <p class="text-muted">Copie o código acima e realize o pagamento no aplicativo do seu banco. Se preferir, pague parte agora e complete depois em <strong>Pagamentos</strong>.</p>
                             </div>
                             <?php
                         }

--- a/publico/doRenovarMatricula.php
+++ b/publico/doRenovarMatricula.php
@@ -207,6 +207,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
                                 <pre style="white-space: pre-wrap; word-wrap: break-word;">
                                     <?= $pixPayload ?>
                                 </pre>
+                                <p class="text-muted">Copie o código e pague via Pix. O valor pode ser quitado parcialmente e completado depois em <strong>Pagamentos</strong>.</p>
                             </div>
                             <?php
                         }
@@ -301,18 +302,15 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
 
 <?php
         }
-        catch(Exception $e)
-        {
-            ?><div class="alert alert-danger"><strong>ERRO!</strong> <?= $e->getMessage() ?>></div><?php
+        catch (Exception $e) {
+            echo "<div class='alert alert-danger'><strong>ERRO!</strong> " . $e->getMessage() . "</div>";
         }
     }
 }
 else
 {
     // No submission found
-    ?>
-    <div class="alert alert-danger"><strong>ERRO!</strong> Não foram submetidos quaisquer dados.</div>
-    <?php
+    echo "<div class='alert alert-danger'><strong>ERRO!</strong> Não foram submetidos quaisquer dados.</div>";
 }
 
 ?>


### PR DESCRIPTION
## Summary
- provide helper to return the Pix payload string
- show payment totals and Pix code in the payment page
- present Pix payload and instructions when enrolling/renewing
- generate real Pix payload when processing an enrollment

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a8648a59c8328b5e3c163e678216a