### PR TITLE
Fix README note about composer packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ CatecheSis requires a standard LAMP stack. Recommended software versions are:
 
 These requirements are listed in the installation manual which ships with the project.
 
-After cloning the repository run `composer install` from the project root to fetch the PHP dependencies. The installed packages include PHPUnit for running the test suite.
+After cloning the repository run `composer install` from the project root to fetch the PHP dependencies. This installs all required libraries, including PHPUnit for running the test suite.
 
 ## Configuration files
 


### PR DESCRIPTION
## Summary
- clarify which composer packages are installed after running `composer install`
- keep mention of PHPUnit as the provided test runner

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688a8bbf58e4832882f065ca6b2b7738