### PR TITLE
Fix undefined update session variable in navbar

### DIFF
--- a/gui/widgets/Navbar/MainNavbar.php
+++ b/gui/widgets/Navbar/MainNavbar.php
@@ -240,7 +240,7 @@ class MainNavbar extends Widget
                     <ul class="nav navbar-nav navbar-right">
 
                         <?php
-                        if($_SESSION['IS_UPDATE_AVAILABLE'])
+                        if(isset($_SESSION['IS_UPDATE_AVAILABLE']) && $_SESSION['IS_UPDATE_AVAILABLE'])
                         {
                         ?>
                         <!-- Updates available -->
@@ -285,7 +285,7 @@ class MainNavbar extends Widget
 
         $this->aboutDialog->renderHTML();
 
-        if($_SESSION['IS_UPDATE_AVAILABLE'])
+        if(isset($_SESSION['IS_UPDATE_AVAILABLE']) && $_SESSION['IS_UPDATE_AVAILABLE'])
         {
             $this->updateDialog->renderHTML();
         }


### PR DESCRIPTION
## Summary
- avoid warnings if `IS_UPDATE_AVAILABLE` session key is unset

## Testing
- `composer install`
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_688a90f29aac8328a87dd9d5dc8c7dde