### PR TITLE
Add payment status management

### DIFF
--- a/core/DatabaseManager.php
+++ b/core/DatabaseManager.php
@@ -237,9 +237,14 @@ interface DatabaseManager
     public function getOldestLSNtoKeep(int $maxRecords);                                                                // Returns the oldest LSN to keep when doing a cleanup, maintaining the most recent $maxRecords records
     // Payments
     public function getPaymentsByUser(string $username);
-                                        // Returns all payment records for the given user
-    public function insertPayment(string $username, int $cid, float $amount, string $status);
-                                        // Inserts a new payment record
+                                          // Returns all payment records for the given user
+    public function insertPayment(string $username, int $cid, float $amount, string $filePath,
+                                  string $status, ?string $obs = null);
+                                          // Inserts a new payment record
+    public function setPaymentStatus(int $pid, string $status, ?string $obs = null);
+                                          // Updates the status of a payment
+    public function getPendingPayments();
+                                          // Lists all payments waiting for approval
     public function deleteLogEntriesOlderThan(int $lsn);                                                                // Deletes CatecheSis log entries older than the provided LSN
 }
 

--- a/tests/PdoDatabaseManagerTest.php
+++ b/tests/PdoDatabaseManagerTest.php
@@ -26,7 +26,9 @@ class PdoDatabaseManagerTest extends TestCase
             username TEXT,
             cid INTEGER,
             valor REAL,
+            ficheiro TEXT,
             estado TEXT,
+            obs TEXT,
             data_pagamento TEXT
         );');
         $this->pdo->exec('CREATE TABLE catequizando (
@@ -55,22 +57,23 @@ class PdoDatabaseManagerTest extends TestCase
 
     public function testInsertPayment(): void
     {
-        $result = $this->manager->insertPayment('john', 1, 10.5, 'pendente');
+        $result = $this->manager->insertPayment('john', 1, 10.5, 'file1.pdf', 'pendente');
         $this->assertTrue($result);
 
-        $stmt = $this->pdo->query('SELECT username, cid, valor, estado FROM pagamentos');
+        $stmt = $this->pdo->query('SELECT username, cid, valor, ficheiro, estado, obs FROM pagamentos');
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
         $this->assertEquals('john', $row['username']);
         $this->assertEquals(1, $row['cid']);
         $this->assertEquals(10.5, $row['valor']);
+        $this->assertEquals('file1.pdf', $row['ficheiro']);
         $this->assertEquals('pendente', $row['estado']);
     }
 
     public function testGetTotalPaymentsByCatechumen(): void
     {
-        $this->manager->insertPayment('john', 1, 10.5, 'pendente');
-        $this->manager->insertPayment('john', 1, 5.5, 'pendente');
+        $this->manager->insertPayment('john', 1, 10.5, 'file1.pdf', 'pendente');
+        $this->manager->insertPayment('john', 1, 5.5, 'file2.pdf', 'pendente');
 
         $total = $this->manager->getTotalPaymentsByCatechumen(1);
         $this->assertEquals(16.0, $total);
@@ -78,9 +81,9 @@ class PdoDatabaseManagerTest extends TestCase
 
     public function testListPaymentsWithStatusAndDebt(): void
     {
-        $this->manager->insertPayment('john', 1, 30.0, 'confirmado');
-        $this->manager->insertPayment('john', 1, 20.0, 'pendente');
-        $this->manager->insertPayment('jane', 2, 50.0, 'confirmado');
+        $this->manager->insertPayment('john', 1, 30.0, 'rec1.pdf', 'aprovado');
+        $this->manager->insertPayment('john', 1, 20.0, 'rec2.pdf', 'pendente');
+        $this->manager->insertPayment('jane', 2, 50.0, 'rec3.pdf', 'aprovado');
 
         $payments = $this->manager->getPaymentsByCatechumen(1);
         $this->assertCount(2, $payments);
@@ -89,12 +92,12 @@ class PdoDatabaseManagerTest extends TestCase
         $this->assertEquals('pendente', $payments[0]['estado']);
         $this->assertEquals(20.0, $payments[0]['valor']);
 
-        $this->assertEquals('confirmado', $payments[1]['estado']);
+        $this->assertEquals('aprovado', $payments[1]['estado']);
         $this->assertEquals(30.0, $payments[1]['valor']);
 
         $totalConfirmed = 0.0;
         foreach ($payments as $p) {
-            if ($p['estado'] === 'confirmado') {
+            if ($p['estado'] === 'aprovado') {
                 $totalConfirmed += floatval($p['valor']);
             }
         }
@@ -102,6 +105,30 @@ class PdoDatabaseManagerTest extends TestCase
         $expectedFee = 100.0;
         $debt = max($expectedFee - $totalConfirmed, 0.0);
         $this->assertEquals(70.0, $debt);
+    }
+
+    public function testSetPaymentStatus(): void
+    {
+        $this->manager->insertPayment('john', 1, 10.0, 'rec.pdf', 'pendente');
+
+        $pid = (int)$this->pdo->query('SELECT pid FROM pagamentos')->fetchColumn();
+
+        $result = $this->manager->setPaymentStatus($pid, 'aprovado', 'ok');
+        $this->assertTrue($result);
+
+        $row = $this->pdo->query('SELECT estado, obs FROM pagamentos WHERE pid='.$pid)->fetch(PDO::FETCH_ASSOC);
+        $this->assertEquals('aprovado', $row['estado']);
+        $this->assertEquals('ok', $row['obs']);
+    }
+
+    public function testGetPendingPayments(): void
+    {
+        $this->manager->insertPayment('john', 1, 10.0, 'p1.pdf', 'pendente');
+        $this->manager->insertPayment('john', 1, 5.0, 'p2.pdf', 'aprovado');
+
+        $pending = $this->manager->getPendingPayments();
+        $this->assertCount(1, $pending);
+        $this->assertEquals('p1.pdf', $pending[0]['ficheiro']);
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- extend payment handling to save file path and observation
- expose methods to update payment status and list pending payments
- include new fields in payment queries
- update unit tests for new functionality

## Testing
- `composer install`
- `./vendor/bin/phpunit --color=never`

------
https://chatgpt.com/codex/tasks/task_e_688bb6534f6483289f8417ef6f9497f2