### PR TITLE
Enforce payment limits

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -5801,6 +5801,23 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
         if(!$this->connectAsNeeded(DatabaseAccessMode::DEFAULT_EDIT))
             throw new Exception('Não foi possível estabelecer uma ligação à base de dados.');
 
+        $max = 0.0;
+        try {
+            $sqlMax = "SELECT valor FROM configuracoes WHERE chave=:chave;";
+            $stmMax = $this->_connection->prepare($sqlMax);
+            $key = Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT;
+            $stmMax->bindParam(':chave', $key);
+            if($stmMax->execute()) {
+                $row = $stmMax->fetch();
+                if($row && isset($row['valor']))
+                    $max = floatval($row['valor']);
+            }
+        } catch (Exception $e) {
+            // ignore and keep max at 0
+        }
+        if($amount > $max)
+            throw new Exception('Valor do pagamento excede a taxa configurada.');
+
         try
         {
             $sql = "INSERT INTO pagamentos(username, cid, valor, estado, data_pagamento) VALUES (:username, :cid, :valor, :estado, NOW());";

--- a/tests/PdoDatabaseManagerTest.php
+++ b/tests/PdoDatabaseManagerTest.php
@@ -78,9 +78,9 @@ class PdoDatabaseManagerTest extends TestCase
 
     public function testListPaymentsWithStatusAndDebt(): void
     {
-        $this->manager->insertPayment('john', 1, 30.0, 'confirmado');
+        $this->manager->insertPayment('john', 1, 15.0, 'confirmado');
         $this->manager->insertPayment('john', 1, 20.0, 'pendente');
-        $this->manager->insertPayment('jane', 2, 50.0, 'confirmado');
+        $this->manager->insertPayment('jane', 2, 20.0, 'confirmado');
 
         $payments = $this->manager->getPaymentsByCatechumen(1);
         $this->assertCount(2, $payments);
@@ -90,7 +90,7 @@ class PdoDatabaseManagerTest extends TestCase
         $this->assertEquals(20.0, $payments[0]['valor']);
 
         $this->assertEquals('confirmado', $payments[1]['estado']);
-        $this->assertEquals(30.0, $payments[1]['valor']);
+        $this->assertEquals(15.0, $payments[1]['valor']);
 
         $totalConfirmed = 0.0;
         foreach ($payments as $p) {
@@ -101,7 +101,13 @@ class PdoDatabaseManagerTest extends TestCase
 
         $expectedFee = 100.0;
         $debt = max($expectedFee - $totalConfirmed, 0.0);
-        $this->assertEquals(70.0, $debt);
+        $this->assertEquals(85.0, $debt);
+    }
+
+    public function testInsertPaymentRejectsTooHighAmount(): void
+    {
+        $this->expectException(Exception::class);
+        $this->manager->insertPayment('john', 1, 25.0, 'pendente');
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- check payment amount in `pagamentos.php`
- enforce fee limit in `PdoDatabaseManager::insertPayment`
- test edge case for excessive payment

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688bb6557fec8328b03a1e3d4ac659ed