### PR TITLE
Fix interface mismatch for insertPayment

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -198,7 +198,8 @@ interface PdoDatabaseManagerInterface extends DatabaseManager
 
     // Payments
 
-    public function insertPayment(string $username, int $cid, float $amount, string $status);
+    public function insertPayment(string $username, int $cid, float $amount, string $status,
+                                  ?string $proofFile=null, ?string $obs=null, ?string $approvedBy=null);
     public function insertPendingPayment(string $username, int $cid, float $amount, string $filePath);
     public function approvePayment(int $pid);
 


### PR DESCRIPTION
## Summary
- update `insertPayment` method signature in `PdoDatabaseManagerInterface`

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit -c phpunit.xml tests/PdoDatabaseManagerTest.php` *(fails: Falha interna ao tentar aceder à base de dados)*

------
https://chatgpt.com/codex/tasks/task_e_688bb544b81c8328b44949b643a6f3c9