### PR TITLE
Fix content range checks

### DIFF
--- a/core/document_uploads/UploadHandler.php
+++ b/core/document_uploads/UploadHandler.php
@@ -503,7 +503,9 @@ protected function get_user_id() {
             $name = $this->upcount_name($name);
         }
         // Keep an existing filename if this is part of a chunked upload:
-        $uploaded_bytes = $this->fix_integer_overflow((int)$content_range[1]);
+        $uploaded_bytes = (
+            is_array($content_range) && isset($content_range[1])
+        ) ? $this->fix_integer_overflow((int)$content_range[1]) : 0;
         while (is_file($this->get_upload_path($name))) {
             if ($uploaded_bytes === $this->get_file_size(
                     $this->get_upload_path($name))) {
@@ -1398,7 +1400,8 @@ protected function get_user_id() {
         $content_range_header = $this->get_server_var('HTTP_CONTENT_RANGE');
         $content_range = $content_range_header ?
             preg_split('/[^0-9]+/', $content_range_header) : null;
-        $size =  $content_range ? $content_range[3] : null;
+        $size =  (is_array($content_range) && isset($content_range[3])) ?
+            $content_range[3] : null;
         $files = array();
         if ($upload) {
             if (is_array($upload['tmp_name'])) {


### PR DESCRIPTION
## Summary
- avoid accessing null content range during chunked uploads
- guard the content range when computing upload size

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: Pix provider connection error / database errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bc1d559708328830d4ef270946e76