### PR TITLE
Update payment approval status

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -5926,7 +5926,7 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
 
         try
         {
-            $sql = "UPDATE pagamentos SET estado='confirmado' WHERE pid=:pid";
+            $sql = "UPDATE pagamentos SET estado='aprovado' WHERE pid=:pid";
             $stm = $this->_connection->prepare($sql);
             $stm->bindParam(':pid', $pid, PDO::PARAM_INT);
             return $stm->execute();

--- a/pagamentos.php
+++ b/pagamentos.php
@@ -82,7 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['cid'])) {
         } elseif ($amount > $balance) {
             $message = "<div class='alert alert-danger'><strong>Erro!</strong> Valor excede o saldo em aberto.</div>";
         } else {
-            $status = 'confirmado';
+            $status = 'aprovado';
             try {
                 $db->beginTransaction();
                 $db->insertPayment(Authenticator::getUsername(), $cid, $amount, $status);

--- a/tests/PdoDatabaseManagerTest.php
+++ b/tests/PdoDatabaseManagerTest.php
@@ -161,7 +161,7 @@ class PdoDatabaseManagerTest extends TestCase
         $this->assertTrue($this->manager->approvePayment($pid));
 
         $status = $this->pdo->query("SELECT estado FROM pagamentos WHERE pid=$pid")->fetchColumn();
-        $this->assertEquals('confirmado', $status);
+        $this->assertEquals('aprovado', $status);
     }
 
     public function testInsertPendingPaymentInvalidAmount(): void


### PR DESCRIPTION
## Summary
- switch approved payment state to `'aprovado'`
- adjust payment form default state
- update expectations in the payment database test

## Testing
- `composer install`
- `./vendor/bin/phpunit tests/PdoDatabaseManagerTest.php` *(fails: Falha interna ao tentar aceder à base de dados)*

------
https://chatgpt.com/codex/tasks/task_e_688bc1d714788328b3486f861f4128c8