### PR TITLE
Fix estado column migration

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -10,4 +10,4 @@ New installations will automatically create the correct table using `updater/sql
 
 ## Payment column additions
 
-Run `updater/sql_scripts/004_add_pagamentos_columns.sql` to add new columns `comprovante`, `status`, `aprovado_por` and `obs` to the `pagamentos` table. These fields are created with default values so the script can be executed safely on existing installations.
+Run `updater/sql_scripts/004_add_pagamentos_columns.sql` to add new columns `comprovante`, `estado`, `aprovado_por` and `obs` to the `pagamentos` table. The script also renames an existing `status` column to `estado` if found. These fields are created with default values so the script can be executed safely on existing installations.


### PR DESCRIPTION
## Summary
- ensure payment migrations use `estado`
- document the correct column name in MIGRATIONS

## Testing
- `composer install`
- `vendor/bin/phpunit --stop-on-failure` *(fails: PdoDatabaseManagerTest::testInsertPayment)*

------
https://chatgpt.com/codex/tasks/task_e_688bc1d887e48328a24d5c4669fffc32