### PR TITLE
Fix default fee when config missing

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -5828,8 +5828,11 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
             $stmMax->bindParam(':chave', $key);
             if($stmMax->execute()) {
                 $row = $stmMax->fetch();
-                if($row && isset($row['valor']))
+                if($row && isset($row['valor'])) {
                     $max = floatval($row['valor']);
+                } else {
+                    $max = Configurator::getConfigurationValueOrDefault($key);
+                }
             }
         } catch (Exception $e) {
             // ignore and keep max at 0


### PR DESCRIPTION
## Summary
- handle missing configuration for enrollment payment amount in `PdoDatabaseManager::insertPayment`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml tests/PdoDatabaseManagerTest.php` *(fails: Falha interna ao tentar aceder à base de dados.)*
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bc1d9568c8328b56fe0dba3c98c69