### PR TITLE
Align payment proof column name

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -10,4 +10,4 @@ New installations will automatically create the correct table using `updater/sql
 
 ## Payment column additions
 
-Run `updater/sql_scripts/004_add_pagamentos_columns.sql` to add new columns `comprovante`, `estado`, `aprovado_por` and `obs` to the `pagamentos` table. The script also renames an existing `status` column to `estado` if found. These fields are created with default values so the script can be executed safely on existing installations.
+Run `updater/sql_scripts/004_add_pagamentos_columns.sql` to add new columns `comprovativo`, `estado`, `aprovado_por` and `obs` to the `pagamentos` table. The script also renames an existing `status` column to `estado` if found. These fields are created with default values so the script can be executed safely on existing installations.

--- a/updater/sql_scripts/004_add_pagamentos_columns.sql
+++ b/updater/sql_scripts/004_add_pagamentos_columns.sql
@@ -1,10 +1,10 @@
 -- Add new columns to pagamentos table if they don't already exist
 -- This script is safe to run multiple times.
 
--- comprovante column
+-- comprovativo column
 SET @exists := (SELECT COUNT(*) FROM information_schema.COLUMNS
-                WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'pagamentos' AND COLUMN_NAME = 'comprovante');
-SET @query := IF(@exists = 0, 'ALTER TABLE pagamentos ADD COLUMN comprovante VARCHAR(255) DEFAULT NULL', 'SELECT 1');
+                WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'pagamentos' AND COLUMN_NAME = 'comprovativo');
+SET @query := IF(@exists = 0, 'ALTER TABLE pagamentos ADD COLUMN comprovativo VARCHAR(255) DEFAULT NULL', 'SELECT 1');
 PREPARE stmt FROM @query; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 -- estado column - rename legacy status column if present


### PR DESCRIPTION
## Summary
- fix naming mismatch by switching migrations to `comprovativo`

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Falha interna ao tentar aceder à base de dados)*

------
https://chatgpt.com/codex/tasks/task_e_688bd738ed6c8328bef634483fda6fc2