### PR TITLE
Fix payment file field usage

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -5806,8 +5806,8 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
      * @param string $username
      * @param int $cid
      * @param float $amount
-     * @param string $filePath
      * @param string $status
+     * @param string|null $proofFile
      * @param string|null $obs
      * @return bool
      * @throws Exception
@@ -5851,7 +5851,6 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
             $stm->bindParam(':username', $username);
             $stm->bindParam(':cid', $cid, PDO::PARAM_INT);
             $stm->bindParam(':valor', $amount);
-            $stm->bindParam(':ficheiro', $filePath);
             $stm->bindParam(':estado', $status);
 
             $stm->bindParam(':comprovativo', $proofFile);
@@ -5952,7 +5951,7 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
 
         try
         {
-            $sql = "SELECT pid, cid, valor, ficheiro, obs, data_pagamento FROM pagamentos WHERE estado='pendente' ORDER BY data_pagamento ASC;";
+            $sql = "SELECT pid, cid, valor, comprovativo, obs, data_pagamento FROM pagamentos WHERE estado='pendente' ORDER BY data_pagamento ASC;";
             $stm = $this->_connection->prepare($sql);
 
             if($stm->execute())

--- a/tests/PdoDatabaseManagerTest.php
+++ b/tests/PdoDatabaseManagerTest.php
@@ -26,16 +26,13 @@ class PdoDatabaseManagerTest extends TestCase
             username TEXT,
             cid INTEGER,
             valor REAL,
-            ficheiro TEXT,
+            comprovativo TEXT,
             estado TEXT,
 
             data_pagamento TEXT,
-            file_path TEXT
-
-            comprovativo TEXT,
+            file_path TEXT,
             obs TEXT,
             aprovado_por TEXT
-
 
         );');
         $this->pdo->exec('CREATE TABLE catequizando (
@@ -64,23 +61,23 @@ class PdoDatabaseManagerTest extends TestCase
 
     public function testInsertPayment(): void
     {
-        $result = $this->manager->insertPayment('john', 1, 10.5, 'file1.pdf', 'pendente');
+        $result = $this->manager->insertPayment('john', 1, 10.5, 'pendente', 'file1.pdf');
         $this->assertTrue($result);
 
-        $stmt = $this->pdo->query('SELECT username, cid, valor, ficheiro, estado, obs FROM pagamentos');
+        $stmt = $this->pdo->query('SELECT username, cid, valor, comprovativo, estado, obs FROM pagamentos');
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
         $this->assertEquals('john', $row['username']);
         $this->assertEquals(1, $row['cid']);
         $this->assertEquals(10.5, $row['valor']);
-        $this->assertEquals('file1.pdf', $row['ficheiro']);
+        $this->assertEquals('file1.pdf', $row['comprovativo']);
         $this->assertEquals('pendente', $row['estado']);
     }
 
     public function testGetTotalPaymentsByCatechumen(): void
     {
-        $this->manager->insertPayment('john', 1, 10.5, 'file1.pdf', 'pendente');
-        $this->manager->insertPayment('john', 1, 5.5, 'file2.pdf', 'pendente');
+        $this->manager->insertPayment('john', 1, 10.5, 'pendente', 'file1.pdf');
+        $this->manager->insertPayment('john', 1, 5.5, 'pendente', 'file2.pdf');
 
         $total = $this->manager->getTotalPaymentsByCatechumen(1);
         $this->assertEquals(16.0, $total);
@@ -89,7 +86,7 @@ class PdoDatabaseManagerTest extends TestCase
     public function testListPaymentsWithStatusAndDebt(): void
     {
 
-        $this->manager->insertPayment('john', 1, 15.0, 'confirmado');
+        $this->manager->insertPayment('john', 1, 15.0, 'aprovado');
         $this->manager->insertPayment('john', 1, 20.0, 'pendente');
         $this->manager->insertPayment('jane', 2, 20.0, 'confirmado');
 
@@ -101,7 +98,7 @@ class PdoDatabaseManagerTest extends TestCase
         $this->assertEquals('pendente', $payments[0]['estado']);
         $this->assertEquals(20.0, $payments[0]['valor']);
 
-        $this->assertEquals('confirmado', $payments[1]['estado']);
+        $this->assertEquals('aprovado', $payments[1]['estado']);
         $this->assertEquals(15.0, $payments[1]['valor']);
 
 
@@ -125,7 +122,7 @@ class PdoDatabaseManagerTest extends TestCase
 
     public function testSetPaymentStatus(): void
     {
-        $this->manager->insertPayment('john', 1, 10.0, 'rec.pdf', 'pendente');
+        $this->manager->insertPayment('john', 1, 10.0, 'pendente', 'rec.pdf');
 
         $pid = (int)$this->pdo->query('SELECT pid FROM pagamentos')->fetchColumn();
 
@@ -139,12 +136,12 @@ class PdoDatabaseManagerTest extends TestCase
 
     public function testGetPendingPayments(): void
     {
-        $this->manager->insertPayment('john', 1, 10.0, 'p1.pdf', 'pendente');
-        $this->manager->insertPayment('john', 1, 5.0, 'p2.pdf', 'aprovado');
+        $this->manager->insertPayment('john', 1, 10.0, 'pendente', 'p1.pdf');
+        $this->manager->insertPayment('john', 1, 5.0, 'aprovado', 'p2.pdf');
 
         $pending = $this->manager->getPendingPayments();
         $this->assertCount(1, $pending);
-        $this->assertEquals('p1.pdf', $pending[0]['ficheiro']);
+        $this->assertEquals('p1.pdf', $pending[0]['comprovativo']);
     }
 
     public function testInsertPendingPaymentWithFileAndApprove(): void


### PR DESCRIPTION
## Summary
- clean up insertPayment() parameter handling
- query comprovativo instead of ficheiro for pending payments
- update tests for comprovativo field

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688bd735da9c8328bd05b4251c2ec5ce