### PR TITLE
Fix payment proof CID retrieval

### DIFF
--- a/core/DatabaseManager.php
+++ b/core/DatabaseManager.php
@@ -237,6 +237,7 @@ interface DatabaseManager
     public function getOldestLSNtoKeep(int $maxRecords);                                                                // Returns the oldest LSN to keep when doing a cleanup, maintaining the most recent $maxRecords records
     // Payments
     public function getPaymentsByUser(string $username);
+    public function getUserEnrollmentCid(string $username, int $catecheticalYear);
 
                                         // Returns all payment records for the given user
     public function insertPayment(string $username, int $cid, float $amount, string $status,

--- a/pagamentos.php
+++ b/pagamentos.php
@@ -339,7 +339,14 @@ $menu->renderHTML();
       </div>
       <?php } ?>
       <?php if($balance > 0){
-            $cidForm = isset($payments[0]['cid']) ? intval($payments[0]['cid']) : 0; ?>
+            try {
+                $cidForm = $db->getUserEnrollmentCid(Authenticator::getUsername(), Utils::currentCatecheticalYear());
+            } catch(Exception $e) {
+                $cidForm = null;
+            }
+            if(!$cidForm && isset($payments[0]['cid']))
+                $cidForm = intval($payments[0]['cid']);
+            if($cidForm){ ?>
       <div class="panel panel-default" style="margin-top: 20px;">
         <div class="panel-heading"><strong>Enviar comprovativo de pagamento</strong></div>
         <div class="panel-body">
@@ -356,7 +363,9 @@ $menu->renderHTML();
           </form>
         </div>
       </div>
-      <?php } ?>
+      <?php } else { ?>
+      <div class="alert alert-danger"><strong>Erro!</strong> Não foi possível determinar a ficha do catequizando para associar o comprovativo.</div>
+      <?php }} ?>
     </div>
   </div>
   <script type="text/javascript">


### PR DESCRIPTION
## Summary
- lookup catechumen ID from current enrollment when uploading payment proof
- expose `getUserEnrollmentCid` on the database layer

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage` *(fails: Falha interna ao tentar aceder à base de dados)*

------
https://chatgpt.com/codex/tasks/task_e_688bd737ae5c8328ab5afd3d2d1fe4d2