### PR TITLE
Add payment instructions and dashboard for users

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -211,6 +211,7 @@ interface PdoDatabaseManagerInterface extends DatabaseManager
     public function getRecentPayments(int $limit=20);
     public function getPaymentsByCatechumen(int $cid);
     public function getTotalPaymentsByCatechumen(int $cid);
+    public function getUserCatechumensPaymentStatus(string $username, int $catecheticalYear);
     public function getPaymentsSummaryByCatecheticalYear(int $catecheticalYear);
 
 
@@ -6130,6 +6131,55 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
 
             if($stm->execute())
                 return $stm->fetchAll();
+            else
+                throw new Exception('Falha ao obter informação de pagamentos.');
+        }
+        catch(PDOException $e)
+        {
+            throw new Exception('Falha interna ao tentar aceder à base de dados.');
+        }
+    }
+
+    /**
+     * Returns payment status for all catechumens of a user in a catechetical year.
+     * Each entry contains cid, nome, total_pago, saldo and estado.
+     */
+    public function getUserCatechumensPaymentStatus(string $username, int $catecheticalYear)
+    {
+        if(!$this->connectAsNeeded(DatabaseAccessMode::DEFAULT_READ))
+            throw new Exception('Não foi possível estabelecer uma ligação à base de dados.');
+
+        try
+        {
+            $key = Configurator::KEY_ENROLLMENT_PAYMENT_AMOUNT;
+            $sqlAmount = "SELECT valor FROM configuracoes WHERE chave=:chave;";
+            $stmAmount = $this->_connection->prepare($sqlAmount);
+            $stmAmount->bindParam(':chave', $key);
+            $stmAmount->execute();
+            $amountRow = $stmAmount->fetch();
+            $expected = $amountRow ? floatval($amountRow['valor']) : 0.0;
+
+            $sql = "SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado='aprovado' THEN p.valor ELSE 0 END),0) AS total_pago " .
+                   "FROM inscreve i JOIN catequizando c ON c.cid=i.cid " .
+                   "LEFT JOIN pagamentos p ON p.cid=i.cid " .
+                   "WHERE i.username=:username AND i.ano_lectivo=:ano GROUP BY c.cid, c.nome ORDER BY c.nome;";
+
+            $stm = $this->_connection->prepare($sql);
+            $stm->bindParam(':username', $username);
+            $stm->bindParam(':ano', $catecheticalYear, PDO::PARAM_INT);
+
+            if($stm->execute())
+            {
+                $rows = $stm->fetchAll();
+                foreach($rows as &$r){
+                    $total = floatval($r['total_pago']);
+                    $saldo = $expected - $total;
+                    if($saldo < 0) $saldo = 0.0;
+                    $r['saldo'] = $saldo;
+                    $r['estado'] = $saldo > 0 ? 'pendente' : 'pago';
+                }
+                return $rows;
+            }
             else
                 throw new Exception('Falha ao obter informação de pagamentos.');
         }

--- a/processarInscricao.php
+++ b/processarInscricao.php
@@ -1166,17 +1166,11 @@ if(!DataValidationUtils::validateZipCode($codigo_postal, Configurator::getConfig
 
         if($_REQUEST['modo']!="editar")
         {
-                try {
-                    $pixPayload = \catechesis\PixQRCode::generatePixPayload($payment_amount);
-                } catch (Exception $e) {
-                    $pixPayload = null;
-                }
-                echo("<p><strong>Taxa de inscrição: R$ " . number_format($payment_amount, 2, ',', '.') . "</strong></p>");
-                if($pixPayload) {
-                    echo("<p>Pix \"copia e cola\" para pagamento:</p>");
-                    echo("<pre style=\"white-space: pre-wrap; word-wrap: break-word;\">" . $pixPayload . "</pre>");
-                }
-                echo("<p>Voce pode pagar parte do valor agora e completar depois acessando o menu \"Pagamentos\". O sistema atualizara automaticamente o restante e o status do pagamento.</p>");
+                $pixKey = \catechesis\Configurator::getConfigurationValueOrDefault(\catechesis\Configurator::KEY_PIX_KEY) ?? '000000000000';
+                echo("<p><strong>Efetuar pagamento da taxa de inscrição de R$ " . number_format($payment_amount, 2, ',', '.') . "</strong></p>");
+                echo("<p>Chave Pix:</p>");
+                echo("<pre style=\"white-space: pre-wrap; word-wrap: break-word;\">" . \catechesis\Utils::sanitizeOutput($pixKey) . "</pre>");
+                echo("<p>Se não puder pagar agora, poderá fazê-lo depois na página \"Pagamentos\".</p>");
         }
 	
 	


### PR DESCRIPTION
## Summary
- display Pix key and instructions after registration
- add dashboard of catechumens in Payments page
- allow uploading payment proof for any registered child
- expose helper to fetch payment status for user's catechumens

## Testing
- `php -l processarInscricao.php`
- `php -l pagamentos.php`
- `php -l core/PdoDatabaseManager.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0e80cbc0832888f03420fde96966