### PR TITLE
Display payment info for created catechumens

### DIFF
--- a/pagamentos.php
+++ b/pagamentos.php
@@ -115,6 +115,9 @@ if(Authenticator::isAdmin()) {
     try {
         $payments = $db->getPaymentsByUser(Authenticator::getUsername());
         $childrenStatus = $db->getUserCatechumensPaymentStatus(Authenticator::getUsername(), Utils::currentCatecheticalYear());
+        if(count($childrenStatus) === 0) {
+            $childrenStatus = $db->getCreatedCatechumensPaymentStatus(Authenticator::getUsername());
+        }
     } catch (Exception $e) {
         $payments = [];
         $childrenStatus = [];
@@ -302,7 +305,7 @@ $menu->renderHTML();
             </thead>
             <tbody>
             <?php if(count($childrenStatus) === 0){ ?>
-              <tr><td colspan="3" class="text-center">Nenhum catequizando inscrito</td></tr>
+              <tr><td colspan="3" class="text-center">Nenhum catequizando registado</td></tr>
             <?php } else { foreach($childrenStatus as $c){ ?>
               <tr>
                 <td><?= Utils::sanitizeOutput($c['nome']) ?></td>


### PR DESCRIPTION
## Summary
- expose `getCreatedCatechumensPaymentStatus()` in `PdoDatabaseManager`
- show created catechumens on payments dashboard when none enrolled
- list catechumens created by user on *Meus Catequizandos* page
- add coverage for new database method

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688d1869880483288d8ee461bd2b7464