### PR TITLE
Fix created catechumens listing

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -6209,12 +6209,22 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
             $amountRow = $stmAmount->fetch();
             $expected = $amountRow ? floatval($amountRow['valor']) : 0.0;
 
-            $sql = "SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado='aprovado' THEN p.valor ELSE 0 END),0) AS total_pago " .
-                   "FROM catequizando c LEFT JOIN pagamentos p ON p.cid=c.cid " .
-                   "WHERE c.criado_por=:username GROUP BY c.cid, c.nome ORDER BY c.nome;";
+            $numeric = ctype_digit($username);
+            if($numeric) {
+                $sql = "SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado='aprovado' THEN p.valor ELSE 0 END),0) AS total_pago " .
+                       "FROM catequizando c LEFT JOIN pagamentos p ON p.cid=c.cid " .
+                       "WHERE c.criado_por=:uid GROUP BY c.cid, c.nome ORDER BY c.nome;";
+            } else {
+                $sql = "SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado='aprovado' THEN p.valor ELSE 0 END),0) AS total_pago " .
+                       "FROM catequizando c LEFT JOIN pagamentos p ON p.cid=c.cid " .
+                       "WHERE c.criado_por=:username GROUP BY c.cid, c.nome ORDER BY c.nome;";
+            }
 
             $stm = $this->_connection->prepare($sql);
-            $stm->bindParam(':username', $username);
+            if($numeric)
+                $stm->bindParam(':uid', $username, PDO::PARAM_INT);
+            else
+                $stm->bindParam(':username', $username);
 
             if($stm->execute())
             {

--- a/meusCatequizandos.php
+++ b/meusCatequizandos.php
@@ -66,6 +66,7 @@ else
     try {
         $createdList = $db->getCreatedCatechumensPaymentStatus($username);
         if($createdList && count($createdList) > 0) {
+            $error_msg = null;
             foreach($createdList as &$c) {
                 try {
                     $details = $db->getCatechumenById(intval($c['cid']));

--- a/tests/PdoDatabaseManagerTest.php
+++ b/tests/PdoDatabaseManagerTest.php
@@ -191,5 +191,20 @@ class PdoDatabaseManagerTest extends TestCase
         $this->assertEquals(20.0, $mapped[2]['saldo']);
         $this->assertEquals('pendente', $mapped[2]['estado']);
     }
+
+    public function testGetCreatedCatechumensPaymentStatusNumeric(): void
+    {
+        $this->pdo->exec('DROP TABLE catequizando');
+        $this->pdo->exec('CREATE TABLE catequizando (
+            cid INTEGER PRIMARY KEY,
+            nome TEXT,
+            criado_por INTEGER
+        );');
+        $this->pdo->exec("INSERT INTO catequizando (cid, nome, criado_por) VALUES (1, 'Ana', 42)");
+        $this->pdo->exec("INSERT INTO catequizando (cid, nome, criado_por) VALUES (2, 'Bob', 42)");
+        $this->manager->insertPayment('john', 1, 10.0, 'aprovado');
+        $list = $this->manager->getCreatedCatechumensPaymentStatus('42');
+        $this->assertCount(2, $list);
+    }
 }
 ?>


### PR DESCRIPTION
## Summary
- allow `getCreatedCatechumensPaymentStatus` to handle numeric `criado_por`
- ignore initial DB error when fallback list succeeds on `meusCatequizandos.php`
- add regression test for numeric `criado_por`

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688d1c9a451c8328ba8831ae361a48af