### PR TITLE
Simplify getCreatedCatechumensPaymentStatus

### DIFF
--- a/core/PdoDatabaseManager.php
+++ b/core/PdoDatabaseManager.php
@@ -6209,22 +6209,12 @@ class PdoDatabaseManager implements PdoDatabaseManagerInterface
             $amountRow = $stmAmount->fetch();
             $expected = $amountRow ? floatval($amountRow['valor']) : 0.0;
 
-            $numeric = ctype_digit($username);
-            if($numeric) {
-                $sql = "SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado='aprovado' THEN p.valor ELSE 0 END),0) AS total_pago " .
-                       "FROM catequizando c LEFT JOIN pagamentos p ON p.cid=c.cid " .
-                       "WHERE c.criado_por=:uid GROUP BY c.cid, c.nome ORDER BY c.nome;";
-            } else {
-                $sql = "SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado='aprovado' THEN p.valor ELSE 0 END),0) AS total_pago " .
-                       "FROM catequizando c LEFT JOIN pagamentos p ON p.cid=c.cid " .
-                       "WHERE c.criado_por=:username GROUP BY c.cid, c.nome ORDER BY c.nome;";
-            }
+            $sql = "SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado='aprovado' THEN p.valor ELSE 0 END),0) AS total_pago " .
+                   "FROM catequizando c LEFT JOIN pagamentos p ON p.cid=c.cid " .
+                   "WHERE c.criado_por=:username GROUP BY c.cid, c.nome ORDER BY c.nome;";
 
             $stm = $this->_connection->prepare($sql);
-            if($numeric)
-                $stm->bindParam(':uid', $username, PDO::PARAM_INT);
-            else
-                $stm->bindParam(':username', $username);
+            $stm->bindParam(':username', $username);
 
             if($stm->execute())
             {


### PR DESCRIPTION
## Summary
- always filter by `c.criado_por=:username` in `getCreatedCatechumensPaymentStatus`
- drop numeric username handling

## Testing
- `composer install`
- `./vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688d29927d4c832886a4e808efb493fe