### PR TITLE
Improve logging for created catechumens listing

### DIFF
--- a/meusCatequizandos.php
+++ b/meusCatequizandos.php
@@ -64,13 +64,16 @@ if($result && count($result) > 0)
 else
 {
     try {
+        error_log('raw username: "' . $_SESSION['username'] . '"');
+        error_log('getCreatedCatechumensPaymentStatus SQL: SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado=\'aprovado\' THEN p.valor ELSE 0 END),0) AS total_pago FROM catequizando c LEFT JOIN pagamentos p ON p.cid=c.cid WHERE c.criado_por=:username GROUP BY c.cid, c.nome ORDER BY c.nome;');
         $createdList = $db->getCreatedCatechumensPaymentStatus($username);
+        error_log(print_r($createdList, true));
         if($createdList && count($createdList) > 0) {
             $error_msg = null;
             foreach($createdList as &$c) {
                 try {
                     $details = $db->getCatechumenById(intval($c['cid']));
-                    $c = array_merge($details, [
+                    $c = array_merge($c, $details, [
                         'ano_catecismo'=>null,
                         'turma'=>'',
                         'paroquia_batismo'=>'',

--- a/pagamentos.php
+++ b/pagamentos.php
@@ -116,7 +116,10 @@ if(Authenticator::isAdmin()) {
         $payments = $db->getPaymentsByUser(Authenticator::getUsername());
         $childrenStatus = $db->getUserCatechumensPaymentStatus(Authenticator::getUsername(), Utils::currentCatecheticalYear());
         if(count($childrenStatus) === 0) {
+            error_log('raw username: "' . $_SESSION['username'] . '"');
+            error_log('getCreatedCatechumensPaymentStatus SQL: SELECT c.cid, c.nome, IFNULL(SUM(CASE WHEN p.estado=\'aprovado\' THEN p.valor ELSE 0 END),0) AS total_pago FROM catequizando c LEFT JOIN pagamentos p ON p.cid=c.cid WHERE c.criado_por=:username GROUP BY c.cid, c.nome ORDER BY c.nome;');
             $childrenStatus = $db->getCreatedCatechumensPaymentStatus(Authenticator::getUsername());
+            error_log(print_r($childrenStatus, true));
         }
     } catch (Exception $e) {
         $payments = [];


### PR DESCRIPTION
## Summary
- add debug logs before calling `getCreatedCatechumensPaymentStatus()`
- keep existing fields while merging catechumen details

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688d2f3fe46c8328880ff9545fd09395